### PR TITLE
shipit_code_coverage: Use taskcluster-client library instead of manually reimplementing taskcluster API calls

### DIFF
--- a/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
+++ b/src/shipit_code_coverage/shipit_code_coverage/taskcluster.py
@@ -5,6 +5,7 @@ from zipfile import BadZipFile, is_zipfile
 import requests
 
 from cli_common.utils import retry
+from cli_common.taskcluster import get_service
 
 index_base = 'https://index.taskcluster.net/v1/'
 queue_base = 'https://queue.taskcluster.net/v1/'
@@ -20,14 +21,16 @@ def _get_build_platform_name(platform):
 
 
 def get_last_task(platform):
-    r = requests.get(index_base + 'task/gecko.v2.mozilla-central.latest.firefox.{}'.format(_get_build_platform_name(platform)))
+    index = get_service('index')
+    r = index.findTask(index_base + 'task/gecko.v2.mozilla-central.latest.firefox.{}'.format(_get_build_platform_name(platform)))
     r.raise_for_status()
     last_task = r.json()
     return last_task['taskId']
 
 
 def get_task(branch, revision, platform):
-    r = requests.get(index_base + 'task/gecko.v2.{}.revision.{}.firefox.{}'.format(branch, revision, _get_build_platform_name(platform)))
+    index = get_service('index')
+    r = index.findTask(index_base + 'task/gecko.v2.{}.revision.{}.firefox.{}'.format(branch, revision, _get_build_platform_name(platform)))
     task = r.json()
     if r.status_code == requests.codes.ok:
         return task['taskId']
@@ -39,34 +42,34 @@ def get_task(branch, revision, platform):
 
 
 def get_task_details(task_id):
-    r = requests.get(queue_base + 'task/{}'.format(task_id))
+    queue = get_service('queue')
+    r = queue.task(task_id)
     r.raise_for_status()
     return r.json()
 
 
 def get_task_status(task_id):
-    r = requests.get(queue_base + 'task/{}/status'.format(task_id))
+    queue = get_service('queue')
+    r = queue.status(task_id)
     r.raise_for_status()
     return r.json()
 
 
-def get_task_artifacts(task_id):
-    r = requests.get(queue_base + 'task/{}/artifacts'.format(task_id))
+def get_task_artifacts(task_id, artifact_name):
+    index = get_service('index')
+    r = index.findArtifactFromTask(queue_base + 'task/{}/artifacts'.format(task_id), artifact_name)
     r.raise_for_status()
     return r.json()['artifacts']
 
 
 def get_tasks_in_group(group_id):
-    list_url = queue_base + 'task-group/{}/list'.format(group_id)
-
-    r = requests.get(list_url, params={
-        'limit': 200
-    })
+    queue = get_service('queue')
+    r = queue.listTaskGroup(group_id, {'limit': 200})
     r.raise_for_status()
     reply = r.json()
     tasks = reply['tasks']
     while 'continuationToken' in reply:
-        r = requests.get(list_url, params={
+        r = queue.listTaskGroup(group_id, {
             'limit': 200,
             'continuationToken': reply['continuationToken']
         })
@@ -81,7 +84,8 @@ def download_artifact(artifact_path, task_id, artifact_name):
         return artifact_path
 
     def perform_download():
-        r = requests.get(queue_base + 'task/{}/artifacts/{}'.format(task_id, artifact_name), stream=True)
+        index = get_service('index')
+        r = index.findArtifactFromTask(queue_base + 'task/{}/artifacts/{}'.format(task_id, artifact_name))
 
         with open(artifact_path, 'wb') as f:
             r.raw.decode_content = True


### PR DESCRIPTION
replace local taskcluster implementation with taskcluster client library apis

Fixes #934.