### PR TITLE
shipit-workflow: Use decision task for in action context's `taskGroupId`.

### DIFF
--- a/src/shipit_workflow/shipit_workflow/api.py
+++ b/src/shipit_workflow/shipit_workflow/api.py
@@ -158,6 +158,7 @@ def abandon_release(name):
         for phase in filter(lambda x: x.submitted, release.phases):
             actions = fetch_actions_json(phase.task_id)
             action_task_id, action_task, context = generate_action_task(
+                decision_task_id=phase.task_id,
                 action_name='cancel-all',
                 action_task_input={},
                 actions=actions,

--- a/src/shipit_workflow/shipit_workflow/models.py
+++ b/src/shipit_workflow/shipit_workflow/models.py
@@ -134,6 +134,7 @@ class Release(db.Model):
             action_task_input['previous_graph_ids'] = list(previous_graph_ids)
             action_task_input['release_promotion_flavor'] = phase['name']
             action_task_id, action_task, context = generate_action_task(
+                decision_task_id=self.decision_task_id,
                 action_name='release-promotion',
                 action_task_input=action_task_input,
                 actions=self.actions,

--- a/src/shipit_workflow/shipit_workflow/tasks.py
+++ b/src/shipit_workflow/shipit_workflow/tasks.py
@@ -99,13 +99,13 @@ def extract_our_flavors(avail_flavors, product, version, partial_updates):
     return SUPPORTED_FLAVORS[product_key]
 
 
-def generate_action_task(action_name, action_task_input, actions):
+def generate_action_task(decision_task_id, action_name, action_task_input, actions):
     target_action = find_action(action_name, actions)
     context = copy.deepcopy(actions['variables'])  # parameters
     action_task_id = slugid.nice().decode('utf-8')
     context.update({
         'input': action_task_input,
-        'taskGroupId': action_task_id,
+        'taskGroupId': decision_task_id,
         'ownTaskId': action_task_id,
         'taskId': None,
         'task': None,


### PR DESCRIPTION
The action specification[1] documents this as being set to the decision                                                                                                                                            
task id of the task that defined the actions.                                                                                                                                                                      
                                                                                                                                                                                                                   
There is also discussion in scriptworker docs[2] suggesting that it is set                                                                                                                                         
differently for release promotion tasks, so that the created tasks get                                                                                                                                             
created in a new graph. However, it turns out that release-promotion always                                                                                                                                        
creates tasks in a task group named after the action tasks[3][4][5].                                                                                                                                               
                                                                                                                                                                                                                   
[1] https://docs.taskcluster.net/docs/manual/using/actions/spec#json-e-context                                                                                                                                     
[2] https://github.com/mozilla-releng/scriptworker/blob/77bb2f2adfd08ddb22e6cec4d8bc377a58222e87/scriptworker/cot/verify.py#L1240-L1245                                                                            
[3] https://searchfox.org/mozilla-central/rev/f822a0b61631cbb38901569e69b4967176314aa8/taskcluster/taskgraph/actions/release_promotion.py#313                                                                      
[4] https://searchfox.org/mozilla-central/rev/f822a0b61631cbb38901569e69b4967176314aa8/taskcluster/taskgraph/decision.py#173                                                                                       
[5] https://searchfox.org/mozilla-central/rev/f822a0b61631cbb38901569e69b4967176314aa8/taskcluster/taskgraph/create.py#41-47 