### PR TITLE
mach lint is doing more than only js/python (yaml, spell, etc)

### DIFF
--- a/src/shipit_static_analysis/shipit_static_analysis/report/base.py
+++ b/src/shipit_static_analysis/shipit_static_analysis/report/base.py
@@ -20,7 +20,7 @@ COMMENT_PARTS = {
     },
     MozLintIssue: {
         'defect': ' - {nb} found by mozlint',
-        'analyzer': ' - `./mach lint path/to/file` (JS/Python)',
+        'analyzer': ' - `./mach lint path/to/file` (JS/Python/etc)',
     },
 }
 COMMENT_FAILURE = '''

--- a/src/shipit_static_analysis/tests/test_reporter_mozreview.py
+++ b/src/shipit_static_analysis/tests/test_reporter_mozreview.py
@@ -171,7 +171,7 @@ Code analysis found 3 defects in this patch:
 You can run this analysis locally with:
  - `./mach clang-format -p path/to/file.cpp` (C/C++)
  - `./mach static-analysis check path/to/file.cpp` (C/C++)
- - `./mach lint path/to/file` (JS/Python)
+ - `./mach lint path/to/file` (JS/Python/etc)
 
 
 If you see a problem in this automated review, please report it here: https://report.example.com


### PR DESCRIPTION
Fixes #1284.