### PR TITLE
codecoverage/backend: Add v2 coverage endpoint for a revision

### DIFF
--- a/please
+++ b/please
@@ -3,7 +3,7 @@
 set -eu
 
 # DEBUG
-#set -x
+set -x
 
 silent() {
   out=`$@ 2>&1` || echo $out
@@ -26,7 +26,7 @@ if [ "$USE_NIX" = "1" ]; then
   if [ ! -e $nix_store_file ]; then
     echo -n "Building please command (this might take a minute or two the first time) ... ";
   fi
-  silent nix-build nix/default.nix -A please-cli -o result-please-cli;
+  nix-build nix/default.nix -A please-cli -o result-please-cli;
   if [ ! -e $nix_store_file ]; then
     echo "${GREEN}DONE${NC}";
   fi

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.yml
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.yml
@@ -112,3 +112,18 @@ paths:
           description: No base revision has been found on hg.mozilla.org/mozilla-central
       tags:
         - legacy
+
+  /v2/revision/{changeset}:
+    get:
+      operationId: "shipit_code_coverage_backend.v2.coverage_for_revision"
+      parameters:
+      - name: changeset
+        in: path
+        description: Changeset
+        required: true
+        type: string
+      responses:
+        200:
+          description: Code coverage information for a given file or directory at a given changeset
+      tags:
+        - v2

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/services/active_data.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/services/active_data.py
@@ -45,6 +45,7 @@ class ActiveDataCoverage(Coverage):
     FIELD_TEST_SUITE = 'test.suite.~s~'
     FIELD_BUILD_TYPE = 'build.type.~s~'
     FIELD_RUN_NAME = 'run.name.~s~'
+    FIELD_PUSH = 'repo.push.id.~n~'
 
     @staticmethod
     def base_query(filters=[], excludes=[]):

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/__init__.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/__init__.py
@@ -52,4 +52,20 @@ def coverage_for_revision(changeset):
     assert active_data.enabled, \
         'Only ActiveData is supported'
 
-    return coverage_diff(changeset)
+    revision, coverage = coverage_diff(changeset)
+
+    return {
+        'changeset': {
+            'author': revision['changeset']['author'],
+            'bug': revision['changeset']['bug'],
+            'date': revision['changeset']['date'],
+            'description': revision['changeset']['description'],
+            'mercurial': {
+                'hash': revision['changeset']['id'],
+                'repo': revision['branch']['url'],
+                'index': revision['index'],
+            },
+            'push': revision['push']['id'],
+        },
+        'coverage': coverage,
+    }

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/__init__.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/__init__.py
@@ -4,9 +4,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from cli_common import log
 from flask import abort
+import asyncio
 from shipit_code_coverage_backend.v2.base import active_data, NoResults
 from shipit_code_coverage_backend.v2.path import coverage_paths
-from shipit_code_coverage_backend.v2.diff import coverage_diff
+from shipit_code_coverage_backend.v2.diff import coverage_diff, load_raw_patch
 
 logger = log.get_logger(__name__)
 
@@ -52,9 +53,21 @@ def coverage_for_revision(changeset):
     assert active_data.enabled, \
         'Only ActiveData is supported'
 
-    revision, coverage = coverage_diff(changeset)
+    # Run slow tasks in parallel
+    loop = asyncio.get_event_loop()
+    patch, revision = loop.run_until_complete(asyncio.gather(
 
+        # Load raw patch data from hgweb
+        load_raw_patch(changeset),
+
+        # Load coverage for this changeset modifications
+        coverage_diff(changeset)
+    ))
+    loop.close()
+
+    # Output nicely all data
     return {
+        'patch': patch,
         'changeset': {
             'author': revision['changeset']['author'],
             'bug': revision['changeset']['bug'],
@@ -67,5 +80,5 @@ def coverage_for_revision(changeset):
             },
             'push': revision['push']['id'],
         },
-        'coverage': coverage,
+        'coverage': revision['coverage'],
     }

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/__init__.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/__init__.py
@@ -6,6 +6,7 @@ from cli_common import log
 from flask import abort
 from shipit_code_coverage_backend.v2.base import active_data, NoResults
 from shipit_code_coverage_backend.v2.path import coverage_paths
+from shipit_code_coverage_backend.v2.diff import coverage_diff
 
 logger = log.get_logger(__name__)
 
@@ -42,3 +43,13 @@ def coverage_for_path(path='', changeset=None):
         'type': 'directory',
         'children': paths
     }
+
+
+def coverage_for_revision(changeset):
+    '''
+    List coverage changes for any revision
+    '''
+    assert active_data.enabled, \
+        'Only ActiveData is supported'
+
+    return coverage_diff(changeset)

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/base.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/base.py
@@ -15,6 +15,7 @@ logger = log.get_logger(__name__)
 INDEX_COVERAGE = 'coverage'
 INDEX_REPO = 'repo'
 
+
 class NoResults(Exception):
     '''
     Raised when no results were found
@@ -90,6 +91,7 @@ class ActiveData(object):
             'Too many items found for {}'.format(changeset)
 
         return out['hits']['hits'][0]['_source']
+
 
 # Shared instance
 active_data = ActiveData()

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/diff.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/diff.py
@@ -42,11 +42,11 @@ def coverage_in_push(files, push):
                             # Merge all the covered lines, per ES shard
                             'map_script': "params._agg.covered.addAll(doc['source.file.covered.~n~'])",
 
-                            # Make a set per shard
-                            'combine_script': 'return params._agg.covered.stream().distinct().collect(Collectors.toList())',
+                            # Make a list with all items per shard
+                            'combine_script': 'return params._agg.covered.stream().collect(Collectors.toList())',
 
-                            # Merge all sets into a unique result per file (top aggregation)
-                            'reduce_script': 'return params._aggs.stream().flatMap(Collection::stream).distinct().sorted().collect(Collectors.toList())'
+                            # Merge all shards lists into a sorted set per file (top aggregation)
+                            'reduce_script': 'return params._aggs.stream().flatMap(Collection::stream).sorted().distinct().collect(Collectors.toList())'
                         }
                     }
                 }

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/diff.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/diff.py
@@ -159,7 +159,10 @@ def coverage_diff(changeset):
     changes = changes_on_files(files, push, rev['index'], rev['branch']['name'])
 
     # Get final coverage on these files, for this push
-    coverage = coverage_in_push(files, push)
+    try:
+        coverage = coverage_in_push(files, push)
+    except NoResults:
+        coverage = {}
 
     # Rewind the lines covered by unapplying every change
     out = {}
@@ -172,7 +175,7 @@ def coverage_diff(changeset):
 
         file_lines = rewind(file_changes, lines.get(filename))
 
-        file_coverage = coverage.get(filename)
+        file_coverage = coverage.get(filename, [])
         out[filename] = [
             {
                 'line': original_line,
@@ -181,4 +184,4 @@ def coverage_diff(changeset):
             for original_line, final_line in file_lines.items()
         ]
 
-    return out
+    return rev, out

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/diff.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/diff.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from cli_common import log
+from shipit_code_coverage_backend.services.active_data import ActiveDataCoverage
+from shipit_code_coverage_backend.v2.base import active_data, NoResults
+
+logger = log.get_logger(__name__)
+
+
+def coverage_diff(changeset):
+    '''
+    List all the coverage changes introduced by a diff
+    '''
+
+    print('DIFF', changeset)
+
+    # Load revision from MC
+    rev = active_data.get_changeset(changeset)
+
+    from pprint import pprint
+    pprint(rev)
+
+    files = rev['changeset']['files']
+    push = rev['push']['id']
+    logger.info('Looking up coverage', files=files, push=push)
+
+    # Load all the other commits on this push, above this changeset
+    # and for these files
+    query = {
+        'query': {
+            'bool': {
+
+                # Files intersection
+                'should': [
+                    { 'match': {'changeset.files': f}}
+                    for f in files
+                ],
+
+                'must': [
+                    # After our commit
+                    {'range': {
+                        'index': {'gt': rev['index']},
+                    }},
+
+                    # Same push and repo
+                    {'match': {'push.id': push}},
+                    {'match': {'branch.name': rev['branch']['name']}},
+                ]
+            }
+        },
+
+        # Only load moves
+        '_source': ['changeset.moves', 'changeset.description'],
+
+        # Probably should use scan/scroll
+        'size': 100,
+    }
+    try:
+        others = active_data.search('commits_above', body=query, index='repo')
+    except NoResults:
+        others = None
+
+    if others:
+        for o in others['hits']['hits']:
+            print('-' * 40)
+            print(o['_source']['changeset']['description'])
+
+    # Load coverage for these files, on this push
+    # TODO: aggregate covered/uncovered
+    filters = [
+        # Filter by files
+        {'terms': {ActiveDataCoverage.FIELD_FILENAME: files}},
+
+        # Filter by push
+        {'term': {ActiveDataCoverage.FIELD_PUSH: push}},
+    ]
+    query = ActiveDataCoverage.base_query(filters)
+    #query.update({
+    #    'size': 0,
+    #    'aggs': {
+    #        'files': {
+    #            'terms': {'field': ActiveDataCoverage.FIELD_FILENAME},
+
+    #            'aggs': {
+    #                'covered': {
+    #    		"scripted_metric": {
+    #    		    "init_script" : "params._agg.covered = []",
+    #    		    #"map_script" : "params._agg.covered.addAll(doc.source.file.covered)",
+    #    		    "map_script" : "params._agg.covered.add(42)",
+    #    		    "reduce_script" : "Set out = new Set();for (a in params._aggs) { out.addAll(a); } return out.toArray();",
+    #    		}
+    #    	    }
+    #            }
+    #        },
+    #    },
+    #})
+    #query['size'] = 100
+
+    out = active_data.search('coverage_files_push', query, timeout=100)
+
+    from pprint import pprint
+    pprint(out)
+    return {}

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/diff.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/v2/diff.py
@@ -2,10 +2,12 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from pprint import pprint
+
 from cli_common import log
 from shipit_code_coverage_backend.services.active_data import ActiveDataCoverage
-from shipit_code_coverage_backend.v2.base import active_data, NoResults
-from pprint import pprint
+from shipit_code_coverage_backend.v2.base import NoResults
+from shipit_code_coverage_backend.v2.base import active_data
 
 logger = log.get_logger(__name__)
 
@@ -34,17 +36,17 @@ def coverage_in_push(files, push):
 
                 'aggs': {
                     'covered': {
-                        "scripted_metric": {
-                            "init_script" : "params._agg.covered = []",
+                        'scripted_metric': {
+                            'init_script': 'params._agg.covered = []',
 
                             # Merge all the covered lines, per ES shard
-                            "map_script" : "params._agg.covered.addAll(doc['source.file.covered.~n~'])",
+                            'map_script': 'params._agg.covered.addAll(doc[\'source.file.covered.~n~\'])',
 
                             # Make a set per shard
-                            "combine_script" : "return params._agg.covered.stream().distinct().collect(Collectors.toList())",
+                            'combine_script': 'return params._agg.covered.stream().distinct().collect(Collectors.toList())',
 
                             # Merge all sets into a unique result per file (top aggregation)
-                            "reduce_script" : "return params._aggs.stream().flatMap(Collection::stream).distinct().sorted().collect(Collectors.toList())"
+                            'reduce_script': 'return params._aggs.stream().flatMap(Collection::stream).distinct().sorted().collect(Collectors.toList())'
                         }
                     }
                 }
@@ -71,7 +73,7 @@ def changes_on_files(files, push, revision_index, branch_name):
 
                 # Files intersection
                 'should': [
-                    { 'match': {'changeset.files': f}}
+                    {'match': {'changeset.files': f}}
                     for f in files
                 ],
 
@@ -123,7 +125,7 @@ def coverage_diff(changeset):
     # Load revision from MC
     rev = active_data.get_changeset(changeset)
 
-    print('-'* 80)
+    print('-' * 80)
     print('REVISION:')
     pprint(rev)
 
@@ -135,11 +137,11 @@ def coverage_diff(changeset):
     # and for these files
     changes = changes_on_files(files, push, rev['index'], rev['branch']['name'])
 
-    print('-'* 80)
+    print('-' * 80)
     print('Changes:')
     pprint(changes)
 
-    print('-'* 80)
+    print('-' * 80)
     print('FILES PUSH:')
     pprint(coverage_in_push(files, push))
     return {}


### PR DESCRIPTION
Add a new endpoint to retrieve details for a changeset, with its coverage:

* full patch from hgweb
* changeset informations (mercurial infos, author, date, description, bugzilla id)
* lines covered at this revision