### PR TITLE
shipit-workflow: prefer env variables

### DIFF
--- a/lib/cli_common/cli_common/taskcluster.py
+++ b/lib/cli_common/cli_common/taskcluster.py
@@ -135,6 +135,7 @@ def get_secrets(name,
                                       )
         all_secrets = secrets_service.get(name).get('secret', dict())
 
+    # TODO: add comments
     secrets_common = all_secrets.get('common', dict())
     secrets.update(secrets_common)
 

--- a/lib/cli_common/cli_common/taskcluster.py
+++ b/lib/cli_common/cli_common/taskcluster.py
@@ -117,10 +117,15 @@ def get_secrets(name,
                 taskcluster_access_token=None,
                 ):
     '''
-    Fetch a specific set of secrets by name
-    - merge project specific secrets
-    - check that all required secrets are present
-    - extend existing set of secrets
+    Fetch a specific set of secrets by name and verify that the required
+    secrets exist.
+
+    Merge secrets in the following order (the latter overrides the former):
+        - `existing` argument
+        - common secrets, specified under the `common` key in the secrets
+          object
+        - project specific secrets, specified under the `project_name` key in
+          the secrets object
     '''
 
     secrets = dict()
@@ -135,7 +140,6 @@ def get_secrets(name,
                                       )
         all_secrets = secrets_service.get(name).get('secret', dict())
 
-    # TODO: add comments
     secrets_common = all_secrets.get('common', dict())
     secrets.update(secrets_common)
 

--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -692,21 +692,20 @@ PROJECTS_CONFIG = {
                     },
                 },
             },
-            # XXX: commenting out dockerhub deployment (for now)
-            # {
-            #     'target': 'DOCKERHUB',
-            #     'options': {
-            #         'testing': {
-            #             'nix_path_attribute': 'dockerflow',
-            #         },
-            #         'staging': {
-            #             'nix_path_attribute': 'dockerflow',
-            #         },
-            #         'production': {
-            #             'nix_path_attribute': 'dockerflow',
-            #         },
-            #     },
-            # },
+            {
+                'target': 'DOCKERHUB',
+                'options': {
+                    'testing': {
+                        'nix_path_attribute': 'dockerflow',
+                    },
+                    'staging': {
+                        'nix_path_attribute': 'dockerflow',
+                    },
+                    'production': {
+                        'nix_path_attribute': 'dockerflow',
+                    },
+                },
+            },
         ],
     },
     'shipit-frontend': {

--- a/src/shipit_workflow/settings.py
+++ b/src/shipit_workflow/settings.py
@@ -28,10 +28,12 @@ secrets = cli_common.taskcluster.get_secrets(
     os.environ.get('TASKCLUSTER_SECRET'),
     shipit_workflow.config.PROJECT_NAME,
     required=required,
-    existing={x: os.environ.get(x) for x in required if x in os.environ},
     taskcluster_client_id=os.environ.get('TASKCLUSTER_CLIENT_ID'),
     taskcluster_access_token=os.environ.get('TASKCLUSTER_ACCESS_TOKEN'),
 )
+
+# override TC secrets with env variables
+secrets.update({x: os.environ.get(x) for x in required if x in os.environ})
 
 locals().update(secrets)
 


### PR DESCRIPTION
cli_common.taskcluster.get_secrets() when called wit `existing` prefers
the Taskcluster secrets over `existing`. This patch should change the
behaviour, so we can override the shared TC secrets with environment
variables per project, that will be set by Dockerflow.