### PR TITLE
shipit_code_coverage_crawler: Add an entry point script for shipit-code-coverage-crawler

### DIFF
--- a/src/shipit_code_coverage_crawler/setup.py
+++ b/src/shipit_code_coverage_crawler/setup.py
@@ -40,4 +40,9 @@ setup(
     include_package_data=True,
     zip_safe=False,
     license='MPL2',
+    entry_points={
+        'console_scripts': [
+            'shipit-code-coverage-crawler = shipit_code_coverage_crawler.cli:main',
+        ]
+    },
 )

--- a/src/shipit_code_coverage_crawler/shipit_code_coverage_crawler/cli.py
+++ b/src/shipit_code_coverage_crawler/shipit_code_coverage_crawler/cli.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import click
+
+from cli_common.cli import taskcluster_options
+from cli_common.log import init_logger
+from shipit_code_coverage_crawler import config
+from shipit_code_coverage_crawler.secrets import secrets
+
+
+@click.command()
+@taskcluster_options
+@click.option(
+    '--cache-root',
+    required=True,
+    help='Cache root, used to pull changesets'
+)
+def main(cache_root,
+         taskcluster_secret,
+         taskcluster_client_id,
+         taskcluster_access_token,
+         ):
+    secrets.load(taskcluster_secret, taskcluster_client_id, taskcluster_access_token)
+
+    init_logger(config.PROJECT_NAME,
+                PAPERTRAIL_HOST=secrets.get('PAPERTRAIL_HOST'),
+                PAPERTRAIL_PORT=secrets.get('PAPERTRAIL_PORT'),
+                SENTRY_DSN=secrets.get('SENTRY_DSN'),
+                MOZDEF=secrets.get('MOZDEF'),
+                )
+
+
+if __name__ == '__main__':
+    main()

--- a/src/shipit_code_coverage_crawler/shipit_code_coverage_crawler/secrets.py
+++ b/src/shipit_code_coverage_crawler/shipit_code_coverage_crawler/secrets.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from cli_common.taskcluster import get_secrets
+from shipit_code_coverage_crawler import config
+
+
+class Secrets(dict):
+    def load(self, taskcluster_secret, taskcluster_client_id, taskcluster_access_token):
+        secrets = get_secrets(
+            taskcluster_secret,
+            config.PROJECT_NAME,
+            required=(),
+            taskcluster_client_id=taskcluster_client_id,
+            taskcluster_access_token=taskcluster_access_token,
+        )
+
+        self.update(secrets)
+
+
+secrets = Secrets()


### PR DESCRIPTION
This is adding an entry point for the shipit-code-coverage-crawler project.
After this PR is merged, you should be able to run the project like this:
`./please shell shipit-code-coverage-crawler`
In the shell created:
`shipit-code-coverage-crawler --cache-root tmp`