### PR TITLE
please_cli: Add name of the project to the exception thrown when running a not-runnable application

### DIFF
--- a/lib/please_cli/please_cli/run.py
+++ b/lib/please_cli/please_cli/run.py
@@ -62,7 +62,7 @@ def cmd(ctx, project, quiet, nix_shell,
     run_options = project_config.get('run_options', {})
 
     if not run_type:
-        raise click.ClickException('Application `{}` is not configured to be runnable.')
+        raise click.ClickException('Application `{}` is not configured to be runnable.'.format(project))
 
     host = run_options.get('host', 'localhost')
     if please_cli.config.IN_DOCKER:


### PR DESCRIPTION
Fixes #1328 