### PR TITLE
please_cli: use docker repos per project/channel

### DIFF
--- a/lib/please_cli/please_cli/base_image.py
+++ b/lib/please_cli/please_cli/base_image.py
@@ -47,8 +47,8 @@ log = cli_common.log.get_logger(__name__)
 @click.option(
     '--docker-repo',
     required=True,
-    default=please_cli.config.DOCKER_REPO,
-    help='Docker repository (default: {}).'.format(please_cli.config.DOCKER_REPO),
+    default=please_cli.config.DOCKER_BASE_REPO,
+    help='Docker repository.',
     )
 @click.option(
     '--docker-tag',

--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -40,8 +40,7 @@ TMP_DIR = os.path.join(ROOT_DIR, 'tmp')
 CHANNELS = ['master', 'testing', 'staging', 'production']
 DEPLOY_CHANNELS = ['testing', 'staging', 'production']
 
-DOCKER_REGISTRY = "index.docker.io"
-DOCKER_REPO = 'mozillareleng/services'
+DOCKER_BASE_REPO = 'mozillareleng/services'
 DOCKER_BASE_TAG = 'base-' + VERSION
 
 NIX_BIN_DIR = os.environ.get("NIX_BIN_DIR", "")  # must end with /
@@ -384,14 +383,20 @@ PROJECTS_CONFIG = {
                     'testing': {
                         'nix_path_attribute': 'cron.replicate.testing',
                         'name-suffix': '-replicate',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'staging': {
                         'nix_path_attribute': 'cron.replicate.staging',
                         'name-suffix': '-replicate',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'production': {
                         'nix_path_attribute': 'cron.replicate.production',
                         'name-suffix': '-replicate',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                 },
             },
@@ -401,14 +406,20 @@ PROJECTS_CONFIG = {
                     'testing': {
                         'nix_path_attribute': 'cron.check_pending_uploads.testing',
                         'name-suffix': '-check_pending_uploads',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'staging': {
                         'nix_path_attribute': 'cron.check_pending_uploads.staging',
                         'name-suffix': '-check_pending_uploads',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'production': {
                         'nix_path_attribute': 'cron.check_pending_uploads.production',
                         'name-suffix': '-check_pending_uploads',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                 },
             },
@@ -469,12 +480,18 @@ PROJECTS_CONFIG = {
                 'options': {
                     'testing': {
                         'nix_path_attribute': 'deploy.testing',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'staging': {
                         'nix_path_attribute': 'deploy.staging',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'production': {
                         'nix_path_attribute': 'deploy.production',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                 },
             },
@@ -491,12 +508,18 @@ PROJECTS_CONFIG = {
                 'options': {
                     'testing': {
                         'nix_path_attribute': 'deploy.testing',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'staging': {
                         'nix_path_attribute': 'deploy.staging',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'production': {
                         'nix_path_attribute': 'deploy.production',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                 },
             },
@@ -554,12 +577,18 @@ PROJECTS_CONFIG = {
                 'options': {
                     'testing': {
                         'nix_path_attribute': 'deploy.testing',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'staging': {
                         'nix_path_attribute': 'deploy.staging',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'production': {
                         'nix_path_attribute': 'deploy.production',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                 },
             },
@@ -605,12 +634,18 @@ PROJECTS_CONFIG = {
                 'options': {
                     'testing': {
                         'nix_path_attribute': 'deploy.testing',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'staging': {
                         'nix_path_attribute': 'deploy.staging',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                     'production': {
                         'nix_path_attribute': 'deploy.production',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozillareleng/services',
                     },
                 },
             },
@@ -736,14 +771,20 @@ PROJECTS_CONFIG = {
                     'testing': {
                         'url': 'https://api.shipit.testing.mozilla-releng.net',
                         'nix_path_attribute': 'dockerflow',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozilla/shipitbackend',
                     },
                     'staging': {
                         'url': 'https://api.shipit.staging.mozilla-releng.net',
                         'nix_path_attribute': 'dockerflow',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozilla/shipitbackend',
                     },
                     'production': {
                         'url': 'https://api.shipit.mozilla-releng.net',
                         'nix_path_attribute': 'dockerflow',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozilla/shipitbackend',
                     },
                 },
             },

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -188,7 +188,7 @@ def get_deploy_task(index,
         )
         command = [
             './please', '-vv', 'tools', 'deploy:DOCKERHUB', project,
-            f'--taskcluster-secret={taskcluster_secret,}',
+            f'--taskcluster-secret={taskcluster_secret}',
             f'--nix-path-attribute={nix_path_attribute}',
             f'--docker-repo={docker_repo}',
             f'--docker-registry={docker_registry}',

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -176,55 +176,55 @@ def get_deploy_task(index,
         ]
 
     elif deploy_target == 'DOCKERHUB':
-        docker_repo = please_cli.config.DOCKER_REPO
+        try:
+            docker_registry = deploy_options['docker_registry']
+            docker_repo = deploy_options['docker_repo']
+        except KeyError:
+            raise click.ClickException('Missing `docker_registry` or `docker_repo` in deploy options')
+
         project_name = (
-            '{project} ({nix_path_attribute}) to DOCKERHUB '
-            '({docker_repo}:{project}-{nix_path_attribute}-{channel})'.format(
-                project=project,
-                nix_path_attribute=nix_path_attribute,
-                docker_repo=docker_repo,
-                channel=channel,
-            )
+            f'{project} ({nix_path_attribute}) to DOCKERHUB '
+            f'({docker_registry}/{docker_repo}:{project}-{nix_path_attribute}-{channel})'
         )
         command = [
             './please', '-vv', 'tools', 'deploy:DOCKERHUB', project,
-            '--taskcluster-secret=' + taskcluster_secret,
-            '--nix-path-attribute={}'.format(nix_path_attribute),
-            '--docker-repo={}'.format(docker_repo),
-            '--channel={}'.format(channel),
+            f'--taskcluster-secret={taskcluster_secret,}',
+            f'--nix-path-attribute={nix_path_attribute}',
+            f'--docker-repo={docker_repo}',
+            f'--docker-registry={docker_registry}',
+            f'--channel={channel}',
             '--no-interactive',
         ]
 
     elif deploy_target == 'TASKCLUSTER_HOOK':
+        try:
+            docker_registry = deploy_options['docker_registry']
+            docker_repo = deploy_options['docker_repo']
+        except KeyError:
+            raise click.ClickException('Missing `docker_registry` or `docker_repo` in deploy options')
         hook_group_id = 'project-releng'
-        hook_id = 'services-{}-{}{}'.format(
-            channel,
-            project,
-            deploy_options.get('name-suffix', ''),
-        )
-        project_name = '{}{} to TASKCLUSTER HOOK ({}/{})'.format(
-            project,
-            ' ({})'.format(nix_path_attribute),
-            hook_group_id,
-            hook_id,
-        )
+        name_suffix = deploy_options.get('name-suffix', '')
+        hook_id = f'services-{channel}-{project}{name_suffix}'
+        project_name = f'{project} ({nix_path_attribute}) to TASKCLUSTER HOOK ({hook_group_id}/{hook_id})'
         command = [
             './please', '-vv',
             'tools', 'deploy:TASKCLUSTER_HOOK',
             project,
-            '--hook-group-id={}'.format(hook_group_id),
-            '--hook-id={}'.format(hook_id),
-            '--taskcluster-secret=' + taskcluster_secret,
-            '--nix-path-attribute=' + nix_path_attribute,
+            f'--docker-registry={docker_registry}',
+            f'--docker-repo={docker_repo}',
+            f'--hook-group-id={hook_group_id}',
+            f'--hook-id={hook_id}',
+            f'--taskcluster-secret={taskcluster_secret}',
+            f'--nix-path-attribute={nix_path_attribute}',
             '--no-interactive',
         ]
         scopes += [
-          'assume:hook-id:project-releng/services-{}-*'.format(channel),
-          'hooks:modify-hook:project-releng/services-{}-*'.format(channel),
+          f'assume:hook-id:project-releng/services-{channel}-*',
+          f'hooks:modify-hook:project-releng/services-{channel}-*',
         ]
 
     else:
-        raise click.ClickException('Unknown deployment target `{}` for project `{}`'.format(deploy_target, project))
+        raise click.ClickException(f'Unknown deployment target `{deploy_target}` for project `{project}`')
 
     return get_task(
         task_group_id,
@@ -289,7 +289,7 @@ def get_task(task_group_id,
         'priority': priority,
         'payload': {
             'maxRunTime': 60 * 60 * max_run_time_in_hours,
-            'image': '{}:{}'.format(please_cli.config.DOCKER_REPO,
+            'image': '{}:{}'.format(please_cli.config.DOCKER_BASE_REPO,
                                     please_cli.config.DOCKER_BASE_TAG),
             'features': {
                 'taskclusterProxy': True,

--- a/lib/please_cli/please_cli/deploy.py
+++ b/lib/please_cli/please_cli/deploy.py
@@ -378,13 +378,11 @@ def cmd_HEROKU(ctx,
 @click.option(
     '--docker-registry',
     required=True,
-    default=please_cli.config.DOCKER_REGISTRY,
     help='Docker registry.',
     )
 @click.option(
     '--docker-repo',
     required=True,
-    default=please_cli.config.DOCKER_REPO,
     help='Docker repository.',
     )
 @click.option(
@@ -541,13 +539,11 @@ def cmd_TASKCLUSTER_HOOK(ctx,
 @click.option(
     '--docker-registry',
     required=True,
-    default=please_cli.config.DOCKER_REGISTRY,
     help='Docker registry.',
     )
 @click.option(
     '--docker-repo',
     required=True,
-    default=please_cli.config.DOCKER_REPO,
     help='Docker repository.',
     )
 @click.option(


### PR DESCRIPTION
This allows us to override docker repos we use to push images. This is
required by dockerflow, which expects images under mozilla/.