### PR TITLE
please_cli: do not print environment variables

### DIFF
--- a/lib/please_cli/please_cli/shell.py
+++ b/lib/please_cli/please_cli/shell.py
@@ -151,7 +151,7 @@ def cmd(project, zsh, quiet, command, nix_shell,
 
     click.echo(' => Setting environment variables:')
     for env_name, env_value in envs.items():
-        click.echo(f'    - {env_name}="{env_value}"')
+        click.echo(f'    - {env_name}')
         os.environ[env_name] = env_value
 
     if command:


### PR DESCRIPTION
In case we set some secrets from the environment variables, we shouldn't
print their values, so they are not logged.