### PR TITLE
please_cli: Support redis.

### DIFF
--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -56,7 +56,7 @@ TEMPLATES = {
     'backend-json-api': {}
 }
 
-DEV_PROJECTS = ['postgresql']
+DEV_PROJECTS = ['postgresql', 'redis']
 PROJECTS = list(map(lambda x: x.replace('_', '-')[len(SRC_DIR) + 1:],
                     filter(lambda x: os.path.exists(os.path.join(SRC_DIR, x, 'default.nix')),
                            glob.glob(SRC_DIR + '/*') + glob.glob(SRC_DIR + '/*/*'))))
@@ -70,6 +70,13 @@ PROJECTS_CONFIG = {
         'run_options': {
             'port': 9000,
             'data_dir': os.path.join(TMP_DIR, 'postgresql'),
+        },
+    },
+    'redis': {
+        'run': 'REDIS',
+        'run_options': {
+            'port': 6379,
+            'data_dir': os.path.join(TMP_DIR, 'redis'),
         },
     },
     'releng-notification-policy': {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -51,7 +51,7 @@ let
     "redis" =
       pkgs.stdenv.mkDerivation
         { name = "${pkgs.redis.name}-env";
-          buildInputs = [ pkgs.redis];
+          buildInputs = [ pkgs.redis ];
           passthru.package = pkgs.redis;
         };
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -48,6 +48,13 @@ let
           passthru.package = pkgs.postgresql95;
         };
 
+    "redis" =
+      pkgs.stdenv.mkDerivation
+        { name = "${pkgs.redis.name}-env";
+          buildInputs = [ pkgs.redis];
+          passthru.package = pkgs.redis;
+        };
+
     "please-cli" = import ./../lib/please_cli { inherit releng_pkgs; };
     # TODO: backend_common_example = import ./../lib/backend_common/example { inherit releng_pkgs; };
     "frontend-common-example" = import ./../lib/frontend_common/example { inherit releng_pkgs; };


### PR DESCRIPTION
While working on #1393 i noticed that projects requiring redis stopped working since 8b6cef69a.

So i added redis in `PROJECTS_CONFIG` and into the `please_cli` build exactly like postgresql.
I also added a check for projects depending on redis.

This PR is needed for next release.