### PR TITLE
shipit_code_coverage: Schedule chunk mapping generation to run daily

### DIFF
--- a/src/shipit_code_coverage/default.nix
+++ b/src/shipit_code_coverage/default.nix
@@ -53,7 +53,7 @@ let
       hook = mkTaskclusterHook {
         name = "Shipit task aggregating code coverage data";
         owner = "mcastelluccio@mozilla.com";
-        schedule = [ "0 0 0 * * 0" ]; # every week
+        schedule = [ "0 0 0 * * *" ]; # every day
         taskImage = self.docker;
         scopes = [
           # Used by taskclusterProxy


### PR DESCRIPTION
This changes the schedule for running `shipit-code-coverage` to be daily instead of weekly.