### PR TITLE
backend_common: Do not use https in Dockerflow

### DIFF
--- a/lib/backend_common/backend_common/__init__.py
+++ b/lib/backend_common/backend_common/__init__.py
@@ -56,7 +56,9 @@ def create_app(
         app.config.update(**config)
 
     for extension_name in EXTENSIONS:
-        if app.config.get('TESTING') and extension_name in ['security', 'cors']:
+        # Disable HTTPS and friends when in testing mode or in Dockerflow.
+        if (app.config.get('TESTING') or os.environ.get('DOCKERFLOW')) \
+                and extension_name in ['security', 'cors']:
             continue
 
         if extension_name not in extensions:

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -841,6 +841,7 @@ in rec {
         fromImage = self_docker;
         config = self_docker_config // {
             User = dockerUser;
+            Env = self_docker_config.Env ++ [ "DOCKERFLOW=1" ];
         };
         runAsRoot = (if dockerUser == null then "" else ''
           #!${stdenv.shell}


### PR DESCRIPTION
The security extension forces HTTPS when enabled. This patch disables
'security' and 'cors' extensions in case the application is run under
Dockerflow environment.