### PR TITLE
please_cli: normalize project name in body data

### DIFF
--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -13,6 +13,7 @@ import cli_common.taskcluster
 import click
 import click_spinner
 import please_cli.config
+import please_cli.utils
 
 
 PROJECTS = list(set(please_cli.config.PROJECTS) - set(please_cli.config.DEV_PROJECTS))
@@ -131,7 +132,8 @@ def get_deploy_task(index,
                 for i in require_config.get('deploys', [])
             ]
             require_urls = filter(lambda x: x[0] is not None, require_urls)
-            require_urls = map(lambda x: '--env="{}{}-url: {}"'.format(require, x[1], x[0]), require_urls)
+            normalized_require = please_cli.utils.normalize_name(require, normalizer='-')
+            require_urls = map(lambda x: '--env="{}{}-url: {}"'.format(normalized_require, x[1], x[0]), require_urls)
 
             project_envs += require_urls
 

--- a/lib/please_cli/please_cli/utils.py
+++ b/lib/please_cli/please_cli/utils.py
@@ -189,5 +189,5 @@ def docker_image_id(image):
     return 'sha256:{}'.format(image_sha256)
 
 
-def normalize_name(x):
-    return x.replace('/', '_').replace('-', '_')
+def normalize_name(x, normalizer='_'):
+    return x.replace('/', normalizer).replace('-', normalizer)


### PR DESCRIPTION
This fixes the issue when a project names contains a slash (shipit/api)
and we use getConfigFromBody. Currently the console barfs with

`Error: You need to set "data-shipit-api-url"`

and the corresponding HTML looks like:

`<body data-release-version="45" data-release-channel="staging" data-CONFIG="staging" data-shipit/api-url="https://api.shipit.staging.mozilla-releng.net">`