### PR TITLE
[WIP] codecoverage/bot: Ignore directories with coverage artifacts and reports in default.nix

### DIFF
--- a/src/shipit_code_coverage/default.nix
+++ b/src/shipit_code_coverage/default.nix
@@ -108,7 +108,13 @@ let
   self = mkPython {
     inherit python name dirname;
     version = fileContents ./VERSION;
-    src = filterSource ./. { inherit name; };
+      src = filterSource ./. { inherit name; exclude = [
+        "/${name}.egg-info"
+        "/build"
+        "/cache"
+        "/ccov-artifacts"
+        "/code-coverage-reports"
+      ]; };
     buildInputs =
       [ mercurial ] ++
       (fromRequirementsFile ./../../lib/cli_common/requirements-dev.txt python.packages) ++


### PR DESCRIPTION
Try to ignore the directories `src/shipit_code_coverage/ccov-artifacts/` and `src/shipit_code_coverage/code-coverage-reports/` generated by `shipit-code-coverage` when running the project locally.

This does not work, `nix-instantiate nix/default-nix -A please-cli` still running out of memory.

Note: I've tried to introduce syntax errors to the `src/shipit_code_coverage/default.nix` file and they do not get reported, so I guess the OOM happens earlier.