### PR TITLE
uplift/bot: Enable mail notifications for everyone.

### DIFF
--- a/src/uplift/bot/default.nix
+++ b/src/uplift/bot/default.nix
@@ -27,8 +27,7 @@ let
           ("secrets:get:" + secretsKey)
 
           # Email notifications
-          "notify:email:babadie@mozilla.com"
-          "notify:email:sledru@mozilla.com"
+          "notify:email:*"
 
           # Used by cache
           ("docker-worker:cache:" + cacheKey)


### PR DESCRIPTION
We have the `*` email scope now, so we should not request anymore specific addresses.

Triggered because @jankeromnes was added to the recipient list