### PR TITLE
shipit_static_analysis: Enable the debug option build by default

### DIFF
--- a/nix/gecko_env.nix
+++ b/nix/gecko_env.nix
@@ -75,6 +75,7 @@ in gecko.overrideDerivation (old: {
     mozconfig=$out/conf/mozconfig
     echo > $mozconfig "
     ac_add_options --enable-clang-plugin
+    ac_add_options --enable-debug
     ac_add_options --with-clang-path=${clang_4}/bin/clang
     ac_add_options --with-libclang-path=${llvmPackages_4.libclang}/lib
     mk_add_options AUTOCLOBBER=1


### PR DESCRIPTION
debug flag must be enabled by default for our static-analysis
environment.

Fixes #836.