### PR TITLE
Don't enable clang-plugin in static-analysis environment.

### DIFF
--- a/nix/gecko_env.nix
+++ b/nix/gecko_env.nix
@@ -74,7 +74,6 @@ in gecko.overrideDerivation (old: {
     # Build custom mozconfig
     mozconfig=$out/conf/mozconfig
     echo > $mozconfig "
-    ac_add_options --enable-clang-plugin
     ac_add_options --enable-debug
     ac_add_options --with-clang-path=${clang_4}/bin/clang
     ac_add_options --with-libclang-path=${llvmPackages_4.libclang}/lib


### PR DESCRIPTION
We don’t need to enable clang-plugin in our environment, having it
enabled creates extra work for the configuration process and builds
clang-plugin .so that is not used since we don’t perform an actual
build.