### PR TITLE
Common Phabricator API client

### DIFF
--- a/lib/cli_common/cli_common/phabricator.py
+++ b/lib/cli_common/cli_common/phabricator.py
@@ -5,6 +5,7 @@
 
 import functools
 import logging
+from urllib.parse import urlparse
 
 import requests
 
@@ -64,6 +65,11 @@ class PhabricatorAPI(object):
         # Test authentication
         self.user = self.request('user.whoami')
         logger.info('Authenticated on {} as {}'.format(self.url, self.user['realName']))
+
+    @property
+    def hostname(self):
+        parts = urlparse(self.url)
+        return parts.netloc
 
     def load_diff(self, diff_phid=None, revision_phid=None):
         '''

--- a/lib/cli_common/cli_common/phabricator.py
+++ b/lib/cli_common/cli_common/phabricator.py
@@ -4,44 +4,210 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import functools
+import logging
 
 import requests
 
-PHABRICATOR_API_URL_TEMPLATE = 'https://phabricator.services.mozilla.com/api/{}'
 HGMO_JSON_REV_URL_TEMPLATE = 'https://hg.mozilla.org/mozilla-central/json-rev/{}'
+MOZILLA_PHABRICATOR_PROD = 'https://phabricator.services.mozilla.com/api/'
+
+
+logger = logging.getLogger(__name__)
 
 
 @functools.lru_cache(maxsize=2048)
-def _revision_exists_on_central(revision):
+def revision_exists_on_central(revision):
     url = HGMO_JSON_REV_URL_TEMPLATE.format(revision)
-    return requests.get(url).ok
+    try:
+        return requests.get(url).ok
+    except Exception as e:
+        logger.warning('Failed to check on hgweb: {}'.format(e))
+        return False
 
 
-def get_base_revision(phabricator_token, revision_phid):
+class ConduitError(Exception):
     '''
-    Searches for the most recent base revision that is available on
-    https://hg.mozilla.org/mozilla-central, starting from a revision PHID.
+    Exception to be raised when Phabricator returns an error response.
     '''
-    data = {
-        'api.token': phabricator_token,
-        'constraints[revisionPHIDs][0]': revision_phid,
-    }
-    headers = {
-        'Accept': 'application/json',
-    }
-    response = requests.post(PHABRICATOR_API_URL_TEMPLATE.format('differential.diff.search'),
-                             data=data,
-                             headers=headers)
-    j = response.json()
-    if j.get('error_code') or j.get('error_info'):
-        raise Exception('{error_code}: {error_info}'.format(**j))
+    def __init__(self, msg, error_code=None, error_info=None):
+        super(ConduitError, self).__init__(msg)
+        self.error_code = error_code
+        self.error_info = error_info
+        logger.warn('Conduit API error {} : {}'.format(
+            self.error_code,
+            self.error_info or 'unknown'
+        ))
 
-    data = j['result']['data']
-    data.sort(key=lambda x: x['id'], reverse=True)
+    @classmethod
+    def raise_if_error(cls, response_body):
+        '''
+        Raise a ConduitError if the provided response_body was an error.
+        '''
+        if response_body['error_code'] is not None:
+            raise cls(
+                response_body.get('error_info'),
+                error_code=response_body.get('error_code'),
+                error_info=response_body.get('error_info')
+            )
 
-    for rev_data in data:
-        for field in rev_data['fields']['refs']:
-            if field['type'] == 'base':
-                revision = field['identifier']
-                if _revision_exists_on_central(revision):
-                    return revision
+
+class PhabricatorAPI(object):
+    '''
+    Phabricator Rest API client
+    '''
+    def __init__(self, api_key, url=MOZILLA_PHABRICATOR_PROD):
+        self.api_key = api_key
+        self.url = url
+        assert self.url.endswith('/api/'), \
+            'Phabricator API must end with /api/'
+
+        # Test authentication
+        self.user = self.request('user.whoami')
+        logger.info('Authenticated on {} as {}'.format(self.url, self.user['realName']))
+
+    def load_diff(self, diff_phid=None, revision_phid=None):
+        '''
+        Find details of a differential diff from a Differential diff or revision
+        '''
+        assert (diff_phid is not None) ^ (revision_phid is not None), \
+            'Provide a diff_phid XOR revision_phid'
+
+        constraints = {}
+        if diff_phid is not None:
+            constraints['phids'] = [diff_phid, ]
+        if revision_phid is not None:
+            constraints['revisionPHIDs'] = [revision_phid, ]
+        out = self.request('differential.diff.search', constraints=constraints)
+
+        data = out['data']
+        assert len(data) == 1, \
+            'Diff not found'
+        diff = data[0]
+
+        # Make all fields easily accessible
+        if 'fields' in diff and isinstance(diff['fields'], dict):
+            diff.update(diff['fields'])
+            del diff['fields']
+
+        # Lookup base revision in refs
+        try:
+            diff['refs'] = {
+                ref['type']: ref
+                for ref in diff['refs']
+            }
+            diff['baseRevision'] = diff['refs']['base']['identifier']
+        except KeyError:
+            pass
+
+        return diff
+
+    def load_raw_diff(self, diff_id):
+        '''
+        Load the raw diff content
+        '''
+        return self.request(
+            'differential.getrawdiff',
+            diffID=diff_id,
+        )
+
+    def load_revision(self, phid):
+        '''
+        Find details of a differential revision
+        '''
+        out = self.request(
+            'differential.revision.search',
+            constraints={
+                'phids': [phid, ],
+            },
+        )
+
+        data = out['data']
+        assert len(data) == 1, \
+            'Revision not found'
+        return data[0]
+
+    def list_comments(self, revision_phid):
+        '''
+        List and format existing inline comments for a revision
+        '''
+        transactions = self.request(
+            'transaction.search',
+            objectIdentifier=revision_phid,
+        )
+        return [
+            {
+
+                'diffID': transaction['fields']['diff']['id'],
+                'filePath': transaction['fields']['path'],
+                'lineNumber': transaction['fields']['line'],
+                'lineLength': transaction['fields']['length'],
+                'content': comment['content']['raw'],
+
+            }
+            for transaction in transactions['data']
+            for comment in transaction['comments']
+            if transaction['type'] == 'inline' and transaction['authorPHID'] == self.user['phid']
+        ]
+
+    def comment(self, revision_id, message):
+        '''
+        Comment on a Differential revision
+        Using a frozen method as new transactions does not
+        seem to support inlines publication
+        '''
+        return self.request(
+            'differential.createcomment',
+            revision_id=revision_id,
+            message=message,
+            attach_inlines=1,
+        )
+
+    def request(self, path, **payload):
+        '''
+        Send a request to Phabricator API
+        '''
+
+        def flatten_params(params):
+            '''
+            Flatten nested objects and lists.
+            Phabricator requires query data in a application/x-www-form-urlencoded
+            format, so we need to flatten our params dictionary.
+            '''
+            assert isinstance(params, dict)
+            flat = {}
+            remaining = list(params.items())
+
+            # Run a depth-ish first search building the parameter name
+            # as we traverse the tree.
+            while remaining:
+                key, o = remaining.pop()
+                if isinstance(o, dict):
+                    gen = o.items()
+                elif isinstance(o, list):
+                    gen = enumerate(o)
+                else:
+                    flat[key] = o
+                    continue
+
+                remaining.extend(('{}[{}]'.format(key, k), v) for k, v in gen)
+
+            return flat
+
+        # Add api token to payload
+        payload['api.token'] = self.api_key
+
+        # Run POST request on api
+        response = requests.post(
+            self.url + path,
+            data=flatten_params(payload),
+        )
+
+        # Check response
+        data = response.json()
+        assert response.ok
+        assert 'error_code' in data
+        ConduitError.raise_if_error(data)
+
+        # Outputs result
+        assert 'result' in data
+        return data['result']

--- a/lib/cli_common/cli_common/phabricator.py
+++ b/lib/cli_common/cli_common/phabricator.py
@@ -19,11 +19,9 @@ logger = logging.getLogger(__name__)
 @functools.lru_cache(maxsize=2048)
 def revision_exists_on_central(revision):
     url = HGMO_JSON_REV_URL_TEMPLATE.format(revision)
-    try:
-        return requests.get(url).ok
-    except Exception as e:
-        logger.warning('Failed to check on hgweb: {}'.format(e))
-        return False
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.ok
 
 
 class ConduitError(Exception):
@@ -94,14 +92,11 @@ class PhabricatorAPI(object):
                 del diff['fields']
 
             # Lookup base revision in refs
-            try:
-                diff['refs'] = {
-                    ref['type']: ref
-                    for ref in diff['refs']
-                }
-                diff['baseRevision'] = diff['refs']['base']['identifier']
-            except KeyError:
-                pass
+            diff['refs'] = {
+                ref['type']: ref
+                for ref in diff['refs']
+            }
+            diff['baseRevision'] = diff['refs']['base']['identifier']
 
             return diff
 

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
@@ -5,9 +5,10 @@
 
 import asyncio
 
+from rq import Queue
+
 from cli_common.phabricator import PhabricatorAPI
 from cli_common.phabricator import revision_exists_on_central
-from rq import Queue
 from shipit_code_coverage_backend import coverage
 from shipit_code_coverage_backend import coverage_by_changeset_impl
 from shipit_code_coverage_backend import coverage_for_file_impl

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
@@ -78,9 +78,10 @@ def phabricator_base_revision_from_phid(revision_phid):
     try:
         phabricator = PhabricatorAPI(secrets.PHABRICATOR_TOKEN)
         diffs = phabricator.search_diffs(revision_phid=revision_phid)
-        revision = diffs[-1]['baseRevision']
-        if revision and revision_exists_on_central(revision):
-            return {'revision': revision}, 200
+        if len(diffs) > 0:
+            revision = diffs[-1]['baseRevision']
+            if revision and revision_exists_on_central(revision):
+                return {'revision': revision}, 200
         return {'error': 'Base revision not found.'}, 404
     except Exception as e:
         return {

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
@@ -77,12 +77,13 @@ def coverage_latest():
 def phabricator_base_revision_from_phid(revision_phid):
     try:
         phabricator = PhabricatorAPI(secrets.PHABRICATOR_TOKEN)
-        diff = phabricator.load_diff(revision_phid=revision_phid)
-        revision = diff.get('baseRevision')
-        if revision and revision_exists_on_central(revision):
-            return {'revision': revision}, 200
+        for diff in phabricator.search_diffs(revision_phid=revision_phid):
+            revision = diff.get('baseRevision')
+            if revision and revision_exists_on_central(revision):
+                return {'revision': revision}, 200
         return {'error': 'Base revision not found.'}, 404
     except Exception as e:
         return {
-            'error': str(e)
+            'error': str(e),
+            'error_code': getattr(e, 'error_code', 'unknown')
         }, 500

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
@@ -77,10 +77,10 @@ def coverage_latest():
 def phabricator_base_revision_from_phid(revision_phid):
     try:
         phabricator = PhabricatorAPI(secrets.PHABRICATOR_TOKEN)
-        for diff in phabricator.search_diffs(revision_phid=revision_phid):
-            revision = diff['baseRevision']
-            if revision and revision_exists_on_central(revision):
-                return {'revision': revision}, 200
+        diffs = phabricator.search_diffs(revision_phid=revision_phid)
+        revision = diffs[-1]['baseRevision']
+        if revision and revision_exists_on_central(revision):
+            return {'revision': revision}, 200
         return {'error': 'Base revision not found.'}, 404
     except Exception as e:
         return {

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
@@ -78,7 +78,7 @@ def phabricator_base_revision_from_phid(revision_phid):
     try:
         phabricator = PhabricatorAPI(secrets.PHABRICATOR_TOKEN)
         for diff in phabricator.search_diffs(revision_phid=revision_phid):
-            revision = diff.get('baseRevision')
+            revision = diff['baseRevision']
             if revision and revision_exists_on_central(revision):
                 return {'revision': revision}, 200
         return {'error': 'Base revision not found.'}, 404

--- a/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
+++ b/src/shipit_code_coverage_backend/shipit_code_coverage_backend/api.py
@@ -5,9 +5,9 @@
 
 import asyncio
 
+from cli_common.phabricator import PhabricatorAPI
+from cli_common.phabricator import revision_exists_on_central
 from rq import Queue
-
-from cli_common.phabricator import PhabricatorAPI, revision_exists_on_central
 from shipit_code_coverage_backend import coverage
 from shipit_code_coverage_backend import coverage_by_changeset_impl
 from shipit_code_coverage_backend import coverage_for_file_impl

--- a/src/shipit_code_coverage_backend/tests/conftest.py
+++ b/src/shipit_code_coverage_backend/tests/conftest.py
@@ -169,6 +169,22 @@ def phabricator_responses():
         content_type='application/json',
     )
 
+    responses.add(
+        responses.POST,
+        'https://phabricator.services.mozilla.com/api/user.whoami',
+        body=json.dumps({
+            'result': {
+                'phid': 'PHID-USER-test1234',
+                'userName': 'Tester',
+                'primaryEmail': 'test@mozilla.com',
+                'realName': 'Mr. Tester',
+            },
+            'error_code': None,
+            'error_info': None
+        }),
+        content_type='application/json',
+    )
+
 
 @pytest.fixture(scope='session')
 def coverage_changeset_by_file():

--- a/src/shipit_code_coverage_backend/tests/test_phabricator.py
+++ b/src/shipit_code_coverage_backend/tests/test_phabricator.py
@@ -32,4 +32,4 @@ def test_phabricator_get_revision_from_phid_api_bad_token(client, phabricator_re
     REVISION_PHID = 'PHID-DREV-esv6jbcptwuju667eiyx'
     resp = client.get(URL_TEMPLATE.format(REVISION_PHID))
     assert resp.status_code == 500
-    assert 'INVALID-AUTH' in resp.json['error']
+    assert 'ERR-INVALID-AUTH' == resp.json['error_code']

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -5,43 +5,16 @@
 
 from urllib.parse import urlparse
 
-import requests
-
 from cli_common import log
+from cli_common.phabricator import PhabricatorAPI
 from static_analysis_bot import Issue
 from static_analysis_bot import stats
 from static_analysis_bot.report.base import Reporter
 from static_analysis_bot.revisions import PhabricatorRevision
 
-logger = log.get_logger(__name__)
-
 BUG_REPORT_URL = 'https://bit.ly/2tb8Qk3'
 
-
-class ConduitError(Exception):
-    '''
-    Exception to be raised when Phabricator returns an error response.
-    '''
-    def __init__(self, msg, error_code=None, error_info=None):
-        super(ConduitError, self).__init__(msg)
-        self.error_code = error_code
-        self.error_info = error_info
-        logger.warn('Conduit API error {} : {}'.format(
-            self.error_code,
-            self.error_info or 'unknown'
-        ))
-
-    @classmethod
-    def raise_if_error(cls, response_body):
-        '''
-        Raise a ConduitError if the provided response_body was an error.
-        '''
-        if response_body['error_code'] is not None:
-            raise cls(
-                response_body.get('error_info'),
-                error_code=response_body.get('error_code'),
-                error_info=response_body.get('error_info')
-            )
+logger = log.get_logger(__name__)
 
 
 class PhabricatorReporter(Reporter):
@@ -49,59 +22,13 @@ class PhabricatorReporter(Reporter):
     API connector to report on Phabricator
     '''
     def __init__(self, configuration, *args):
-        self.url, self.api_key = self.requires(configuration, 'url', 'api_key')
-        assert self.url.endswith('/api/'), \
-            'Phabricator API must end with /api/'
-
-        # Test authentication
-        self.user = self.request('user.whoami')
-        logger.info('Authenticated on phabricator', url=self.url, user=self.user['realName'])
+        url, api_key = self.requires(configuration, 'url', 'api_key')
+        self.api = PhabricatorAPI(api_key, url)
 
     @property
     def hostname(self):
         parts = urlparse(self.url)
         return parts.netloc
-
-    def load_diff(self, phid):
-        '''
-        Find details of a differential diff
-        '''
-        out = self.request(
-            'differential.diff.search',
-            constraints={
-                'phids': [phid, ],
-            },
-        )
-
-        data = out['data']
-        assert len(data) == 1, \
-            'Diff not found'
-        return data[0]
-
-    def load_raw_diff(self, diff_id):
-        '''
-        Load the raw diff content
-        '''
-        return self.request(
-            'differential.getrawdiff',
-            diffID=diff_id,
-        )
-
-    def load_revision(self, phid):
-        '''
-        Find details of a differential revision
-        '''
-        out = self.request(
-            'differential.revision.search',
-            constraints={
-                'phids': [phid, ],
-            },
-        )
-
-        data = out['data']
-        assert len(data) == 1, \
-            'Revision not found'
-        return data[0]
 
     def publish(self, issues, revision):
         '''
@@ -112,7 +39,7 @@ class PhabricatorReporter(Reporter):
             return
 
         # Load existing comments for this revision
-        existing_comments = self.list_comments(revision)
+        existing_comments = self.api.list_comments(revision.phid)
         logger.info('Found {} existing comments on review'.format(len(existing_comments)))
 
         # Use only publishable issues
@@ -130,8 +57,8 @@ class PhabricatorReporter(Reporter):
             logger.info('Added inline comments', ids=[i['id'] for i in inlines])
 
             # Then publish top comment
-            self.comment(
-                revision,
+            self.api.comment(
+                revision.id,
                 self.build_comment(
                     issues=issues,
                     diff_url=revision.diff_url,
@@ -145,44 +72,6 @@ class PhabricatorReporter(Reporter):
         else:
             # TODO: Publish a validated comment ?
             logger.info('No issues to publish on phabricator')
-
-    def list_comments(self, revision):
-        '''
-        List and format existing inline comments for a revision
-        '''
-        transactions = self.request(
-            'transaction.search',
-            objectIdentifier=revision.phid,
-        )
-        return [
-            {
-
-                'diffID': transaction['fields']['diff']['id'],
-                'filePath': transaction['fields']['path'],
-                'lineNumber': transaction['fields']['line'],
-                'lineLength': transaction['fields']['length'],
-                'content': comment['content']['raw'],
-
-            }
-            for transaction in transactions['data']
-            for comment in transaction['comments']
-            if transaction['type'] == 'inline' and transaction['authorPHID'] == self.user['phid']
-        ]
-
-    def comment(self, revision, message):
-        '''
-        Comment on a Differential revision
-        Using a frozen method as new transactions does not
-        seem to support inlines publication
-        '''
-        assert isinstance(revision, PhabricatorRevision)
-
-        return self.request(
-            'differential.createcomment',
-            revision_id=revision.id,
-            message=message,
-            attach_inlines=1,
-        )
 
     def comment_inline(self, revision, issue, existing_comments=[]):
         '''
@@ -203,7 +92,7 @@ class PhabricatorReporter(Reporter):
             logger.info('Skipping existing comment', text=comment['content'], filename=comment['filePath'], line=comment['lineNumber'])
             return
 
-        inline = self.request(
+        inline = self.api.request(
             'differential.createinline',
 
             # This displays on the new file (right side)
@@ -214,53 +103,3 @@ class PhabricatorReporter(Reporter):
             **comment
         )
         return inline
-
-    def request(self, path, **payload):
-        '''
-        Send a request to Phabricator API
-        '''
-
-        def flatten_params(params):
-            '''
-            Flatten nested objects and lists.
-            Phabricator requires query data in a application/x-www-form-urlencoded
-            format, so we need to flatten our params dictionary.
-            '''
-            assert isinstance(params, dict)
-            flat = {}
-            remaining = list(params.items())
-
-            # Run a depth-ish first search building the parameter name
-            # as we traverse the tree.
-            while remaining:
-                key, o = remaining.pop()
-                if isinstance(o, dict):
-                    gen = o.items()
-                elif isinstance(o, list):
-                    gen = enumerate(o)
-                else:
-                    flat[key] = o
-                    continue
-
-                remaining.extend(('{}[{}]'.format(key, k), v) for k, v in gen)
-
-            return flat
-
-        # Add api token to payload
-        payload['api.token'] = self.api_key
-
-        # Run POST request on api
-        response = requests.post(
-            self.url + path,
-            data=flatten_params(payload),
-        )
-
-        # Check response
-        data = response.json()
-        assert response.ok
-        assert 'error_code' in data
-        ConduitError.raise_if_error(data)
-
-        # Outputs result
-        assert 'result' in data
-        return data['result']

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -21,9 +21,9 @@ class PhabricatorReporter(Reporter):
     '''
     API connector to report on Phabricator
     '''
-    def __init__(self, configuration, *args):
-        url, api_key = self.requires(configuration, 'url', 'api_key')
-        self.api = PhabricatorAPI(api_key, url)
+    def setup_api(self, api):
+        assert isinstance(api, PhabricatorAPI)
+        self.api = api
 
     @property
     def hostname(self):

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -3,8 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from urllib.parse import urlparse
-
 from cli_common import log
 from cli_common.phabricator import PhabricatorAPI
 from static_analysis_bot import Issue
@@ -21,14 +19,13 @@ class PhabricatorReporter(Reporter):
     '''
     API connector to report on Phabricator
     '''
+    def __init__(self, api=None, *args, **kwargs):
+        if api is not None:
+            self.setup_api(api)
+
     def setup_api(self, api):
         assert isinstance(api, PhabricatorAPI)
         self.api = api
-
-    @property
-    def hostname(self):
-        parts = urlparse(self.url)
-        return parts.netloc
 
     def publish(self, issues, revision):
         '''

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -109,7 +109,7 @@ class PhabricatorRevision(Revision):
 
         self.diff_id = diff['id']
         self.phid = diff['revisionPHID']
-        self.hg_base = diff.get('baseRevision')
+        self.hg_base = diff['baseRevision']
         revision = self.api.load_revision(self.phid)
         self.id = revision['id']
 
@@ -147,17 +147,14 @@ class PhabricatorRevision(Revision):
         '''
         assert isinstance(repo, hglib.client.hgclient)
 
-        # When we have a base revision, try to update the repo
-        if self.hg_base:
-            try:
-                repo.update(
-                    rev=self.hg_base,
-                    clean=True,
-                )
-            except hglib.error.CommandError as e:
-                logger.warning('Failed to update to base revision', revision=self.hg_base, error=e)
-        else:
-            logger.info('No base revision found.')
+        # Update the repo to base revision
+        try:
+            repo.update(
+                rev=self.hg_base,
+                clean=True,
+            )
+        except hglib.error.CommandError as e:
+            logger.warning('Failed to update to base revision', revision=self.hg_base, error=e)
 
         # Apply the patch on top of repository
         repo.import_(

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -103,8 +103,10 @@ class PhabricatorRevision(Revision):
         self.diff_phid = groups[0]
 
         # Load diff details to get the diff revision
-        print('OOOOOK', self.diff_phid)
-        diff = self.api.load_diff(diff_phid=self.diff_phid)
+        diffs = self.api.search_diffs(diff_phid=self.diff_phid)
+        assert len(diffs) == 1, 'No diff available for {}'.format(self.diff_phid)
+        diff = diffs[0]
+
         self.diff_id = diff['id']
         self.phid = diff['revisionPHID']
         self.hg_base = diff.get('baseRevision')

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -103,6 +103,7 @@ class PhabricatorRevision(Revision):
         self.diff_phid = groups[0]
 
         # Load diff details to get the diff revision
+        print('OOOOOK', self.diff_phid)
         diff = self.api.load_diff(diff_phid=self.diff_phid)
         self.diff_id = diff['id']
         self.phid = diff['revisionPHID']

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -11,6 +11,7 @@ import hglib
 from parsepatch.patch import Patch
 
 from cli_common import log
+from cli_common.phabricator import PhabricatorAPI
 from static_analysis_bot import Issue
 from static_analysis_bot import stats
 from static_analysis_bot.config import REPO_REVIEW
@@ -91,6 +92,7 @@ class PhabricatorRevision(Revision):
     regex = re.compile(r'^(PHID-DIFF-(?:\w+))$')
 
     def __init__(self, description, api):
+        assert isinstance(api, PhabricatorAPI)
         self.api = api
 
         # Parse Diff description

--- a/src/staticanalysis/bot/static_analysis_bot/workflow.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflow.py
@@ -15,6 +15,7 @@ import hglib
 
 from cli_common.command import run_check
 from cli_common.log import get_logger
+from cli_common.phabricator import PhabricatorAPI
 from static_analysis_bot import CLANG_FORMAT
 from static_analysis_bot import CLANG_TIDY
 from static_analysis_bot import MOZLINT
@@ -41,13 +42,17 @@ class Workflow(object):
     '''
     Static analysis workflow
     '''
-    def __init__(self, reporters, analyzers, index_service):
+    def __init__(self, reporters, analyzers, index_service, phabricator_api):
         assert isinstance(analyzers, list)
         assert len(analyzers) > 0, \
             'No analyzers specified, will not run.'
         self.analyzers = analyzers
         assert 'MOZCONFIG' in os.environ, \
             'Missing MOZCONFIG in environment'
+
+        # Use share phabricator API client
+        assert isinstance(phabricator_api, PhabricatorAPI)
+        self.phabricator = phabricator_api
 
         # Save Taskcluster ID for logging
         if 'TASK_ID' in os.environ and 'RUN_ID' in os.environ:

--- a/src/staticanalysis/bot/tests/test_reporter_mail.py
+++ b/src/staticanalysis/bot/tests/test_reporter_mail.py
@@ -54,12 +54,6 @@ def test_mail(mock_issues, mock_phabricator):
     '''
     from static_analysis_bot.report.mail import MailReporter
     from static_analysis_bot.revisions import MozReviewRevision, PhabricatorRevision
-    from static_analysis_bot.report.phabricator import PhabricatorReporter
-
-    phab = PhabricatorReporter({
-        'url': 'http://phabricator.test/api/',
-        'api_key': 'deadbeef',
-    })
 
     def _check_email(request):
         payload = json.loads(request.body)
@@ -93,8 +87,9 @@ def test_mail(mock_issues, mock_phabricator):
     mrev = MozReviewRevision('12345', 'abcdef', '1')
     r.publish(mock_issues, mrev)
 
-    prev = PhabricatorRevision('PHID-DIFF-test', phab)
-    r.publish(mock_issues, prev)
+    with mock_phabricator as api:
+        prev = PhabricatorRevision('PHID-DIFF-test', api)
+        r.publish(mock_issues, prev)
 
     # Check stats
     mock_cls = mock_issues[0].__class__

--- a/src/staticanalysis/bot/tests/test_revisions.py
+++ b/src/staticanalysis/bot/tests/test_revisions.py
@@ -28,14 +28,9 @@ def test_phabricator(mock_phabricator, mock_repository, mock_config):
     Test a phabricator revision
     '''
     from static_analysis_bot.revisions import PhabricatorRevision
-    from static_analysis_bot.report.phabricator import PhabricatorReporter
 
-    api = PhabricatorReporter({
-        'url': 'http://phabricator.test/api/',
-        'api_key': 'deadbeef',
-    })
-
-    r = PhabricatorRevision('PHID-DIFF-testABcd12', api)
+    with mock_phabricator as api:
+        r = PhabricatorRevision('PHID-DIFF-testABcd12', api)
     assert not hasattr(r, 'mercurial')
     assert r.diff_id == 42
     assert r.diff_phid == 'PHID-DIFF-testABcd12'


### PR DESCRIPTION
* Move Phabricator api class from static analysis to common
* Use that class in code coverage backend & sa bot
* Fixes #1214 by switching to base revision when available
* PhabricatorRevision no longer relies on PhabricatorReporter : we can run the bot with phabricator credentials, but without posting reviews (staging can now use production phabricator data and stay silent)