### PR TITLE
Revert "shipit_static_analysis: Remove unnecessary clang references"

### DIFF
--- a/nix/gecko_env.nix
+++ b/nix/gecko_env.nix
@@ -75,8 +75,11 @@ in gecko.overrideDerivation (old: {
     mozconfig=$out/conf/mozconfig
     echo > $mozconfig "
     ac_add_options --enable-debug
+    ac_add_options --with-clang-path=${clang_4}/bin/clang
+    ac_add_options --with-libclang-path=${llvmPackages_4.libclang}/lib
     mk_add_options AUTOCLOBBER=1
     "
+    echo "export CLANG_MOZCONFIG=$mozconfig" >> $geckoenv
 
     # Use updated rust version
     echo "export PATH=${rustChannel.rust}/bin:${rustChannel.cargo}/bin:\$PATH" >> $geckoenv


### PR DESCRIPTION
Reverts mozilla/release-services#1437

Unfortunately it looks like they were required: [log.txt](https://github.com/mozilla/release-services/files/2329117/log.txt)
