### PR TITLE
Revert "shipit_static_analysis: Remove unnecessary clang references"

### DIFF
--- a/nix/gecko_env.nix
+++ b/nix/gecko_env.nix
@@ -75,6 +75,8 @@ in gecko.overrideDerivation (old: {
     mozconfig=$out/conf/mozconfig
     echo > $mozconfig "
     ac_add_options --enable-debug
+    ac_add_options --with-clang-path=${clang_4}/bin/clang
+    ac_add_options --with-libclang-path=${llvmPackages_4.libclang}/lib
     mk_add_options AUTOCLOBBER=1
     "
 


### PR DESCRIPTION
Reverts mozilla/release-services#1437

Unfortunately it looks like they were required: [log.txt](https://github.com/mozilla/release-services/files/2329117/log.txt)