### PR TITLE
Update nixpkgs-mozilla.json to revision 65ef92a7f9f1d5.

### DIFF
--- a/nix/nixpkgs-mozilla.json
+++ b/nix/nixpkgs-mozilla.json
@@ -1,6 +1,6 @@
 {
   "owner": "mozilla",
   "repo": "nixpkgs-mozilla",
-  "rev": "64e9d5c45e228bfb963f197b5f025d6f607d51ae",
-  "sha256": "0hh9dzvlr6fkygjffv74jj650srlz40iphn6zmb1ys0mgbi2i76x"
+  "rev": "65ef92a7f9f1d5bff6be1d4dc86f1cd25c09a004",
+  "sha256": "05f2vx6cqlnwr2gvh18fpj2dbv0332bnnpyfkmy3na1sx757s9xc"
 }


### PR DESCRIPTION
This updates `nixpkgs-mozilla.json` in order to allow a new target to be specified to `rust`.