### PR TITLE
Enabled the static analysis of java files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,3 @@
 /src/**/yarn-error.log
 /tmp
 /w
-
-# ignore emacs generated files
-*~

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 /src/**/yarn-error.log
 /tmp
 /w
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@
 /src/**/yarn-error.log
 /tmp
 /w
+
+# ignore emacs generated files
 *~

--- a/nix/gecko_env.nix
+++ b/nix/gecko_env.nix
@@ -41,7 +41,6 @@ in gecko.overrideDerivation (old: {
     mkdir -p $out/bin
     mkdir -p $out/conf
   '';
-  mozbuild = "/tmp/mozilla-state";
   buildPhase = ''
 
     # Gecko build environment
@@ -62,9 +61,8 @@ in gecko.overrideDerivation (old: {
 
     # Build LDFLAGS and LIBRARY_PATH
     echo "export LDFLAGS=\"$NIX_LDFLAGS\"" >> $geckoenv
-    echo "export SQLITE_LIB=${sqlite.out}/lib/" >> $geckoenv
-    echo "export LIBRARY_PATH=\"$SQLITE_LIB:$CMAKE_LIBRARY_PATH\"" >> $geckoenv
-    echo "export LD_LIBRARY_PATH=\"$SQLITE_LIB:$CMAKE_LIBRARY_PATH\"" >> $geckoenv
+    echo "export LIBRARY_PATH=${sqlite.out}/lib/:\$CMAKE_LIBRARY_PATH" >> $geckoenv
+    echo "export LD_LIBRARY_PATH=${sqlite.out}/lib/:\$CMAKE_LIBRARY_PATH" >> $geckoenv
 
     # Setup Clang & Autoconf
     echo "export CC=${clang_4}/bin/clang" >> $geckoenv
@@ -81,16 +79,6 @@ in gecko.overrideDerivation (old: {
     ac_add_options --with-clang-path=${clang_4}/bin/clang
     ac_add_options --with-libclang-path=${llvmPackages_4.libclang}/lib
     mk_add_options AUTOCLOBBER=1
-
-    # Build Firefox for Android:
-    ac_add_options --enable-application=mobile/android
-    ac_add_options --target=arm-linux-androideabi
-
-    # With the following Android SDK and NDK:
-    ac_add_options --with-android-sdk="$mozbuild/android-sdk-linux/android-sdk-linux"
-    ac_add_options --with-android-ndk="$mozbuild/android-ndk/android-ndk"
-
-    ac_add_options --with-java-bin-path="${openjdk}/bin"
     "
 
     # Use updated rust version

--- a/src/staticanalysis/bot/static_analysis_bot/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/__init__.py
@@ -15,6 +15,7 @@ import abc
 CLANG_TIDY = 'clang-tidy'
 CLANG_FORMAT = 'clang-format'
 MOZLINT = 'mozlint'
+INFER = 'infer'
 
 
 class Issue(abc.ABC):

--- a/src/staticanalysis/bot/static_analysis_bot/config.py
+++ b/src/staticanalysis/bot/static_analysis_bot/config.py
@@ -50,6 +50,7 @@ class Settings(object):
         self.app_channel = app_channel
         self.download({
             'cpp_extensions': frozenset(['.c', '.h', '.cpp', '.cc', '.cxx', '.hh', '.hpp', '.hxx', '.m', '.mm']),
+            'java_extensions': frozenset(['.java']),
         })
         assert 'clang_checkers' in self.config
         assert 'target' in self.config

--- a/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
@@ -10,6 +10,18 @@ import os
 import cli_common.utils
 
 
+ANDROID_MOZCONFIG = '''# Build Firefox for Android:
+ac_add_options --enable-application=mobile/android
+ac_add_options --target=arm-linux-androideabi
+
+# With the following Android SDK and NDK:
+ac_add_options --with-android-sdk="{mozbuild}/android-sdk-linux/android-sdk-linux"
+ac_add_options --with-android-ndk="{mozbuild}/android-ndk/android-ndk"
+
+ac_add_options --with-java-bin-path="{openjdk}/bin"
+'''
+
+
 def setup(job_name='linux64-infer', revision='latest',
           artifact='public/build/infer.tar.xz'):
     '''
@@ -30,16 +42,17 @@ def setup(job_name='linux64-infer', revision='latest',
         artifacts = ['public/build/infer.tar.xz',
                      'project/gecko/android-sdk/android-sdk-linux.tar.xz',
                      'project/gecko/android-ndk/android-ndk.tar.xz']
-        for i in range(len(job_names)):
-            namespace = NAMESPACE.format(job_names[i], revision)
+        for job, artifact in zip(job_names, artifacts):
+            namespace = NAMESPACE.format(job, revision)
             artifact_url = index.buildSignedUrl('findArtifactFromTask',
                                                 indexPath=namespace,
-                                                name=artifacts[i])
+                                                name=artifact)
             target = os.path.join(
                 os.environ['MOZBUILD_STATE_PATH'],
-                os.path.basename(artifacts[i]).split('.')[0],
+                os.path.basename(artifact).split('.')[0],
             )
             cli_common.utils.retry(lambda: download(artifact_url, target))
+            assert os.path.exists(target)
 
 
 def download(artifact_url, target):

--- a/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
@@ -12,6 +12,7 @@ import subprocess
 import cli_common.utils
 
 from cli_common.log import get_logger
+from static_analysis_bot.config import settings
 
 
 logger = get_logger(__name__)
@@ -68,13 +69,10 @@ def download(artifact_url, target):
 
 
 class AndroidConfig():
-    def __init__(self, settings):
-        self.__settings = settings
-
     def __enter__(self):
         # we copy the old mozconfig into the repository, so that we can
         # enable the android build
-        self.__android_mozconfig = os.path.join(self.__settings.repo_dir, 'mozconfig')
+        self.__android_mozconfig = os.path.join(settings.repo_dir, 'mozconfig')
         self.__old_config = os.getenv('MOZCONFIG')
         shutil.copy(self.__old_config, self.__android_mozconfig)
         os.environ['MOZCONFIG'] = self.__android_mozconfig

--- a/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import tarfile
+import requests
+import io
+import os
+import cli_common.utils
+
+
+def setup(job_name='linux64-infer', revision='latest',
+          artifact='public/build/infer.tar.xz'):
+    '''
+    Setup Taskcluster infer build for static-analysis
+    Defaults values are from https://dxr.mozilla.org/mozilla-central/source/taskcluster/ci/toolchain/linux.yml
+    - Download the artifact from latest Taskcluster build
+    - Extracts it into the MOZBUILD_STATE_PATH as expected by mach
+    '''
+    NAMESPACE = 'gecko.cache.level-1.toolchains.v2.{}.{}'
+    import taskcluster
+    index = taskcluster.Index(
+        {'credentials': {'clientId': os.getenv('TASKCLUSTER_CLIENT_ID'),
+                         'accessToken': os.getenv('TASKCLUSTER_ACCESS_TOKEN')}}
+    )
+    if job_name == 'linux64-infer':
+        job_names = ['linux64-infer', 'linux64-android-sdk-linux-repack',
+                     'linux64-android-ndk-linux-repack']
+        artifacts = ['public/build/infer.tar.xz',
+                     'project/gecko/android-sdk/android-sdk-linux.tar.xz',
+                     'project/gecko/android-ndk/android-ndk.tar.xz']
+        for i in range(len(job_names)):
+            namespace = NAMESPACE.format(job_names[i], revision)
+            artifact_url = index.buildSignedUrl('findArtifactFromTask',
+                                                indexPath=namespace,
+                                                name=artifacts[i])
+            target = os.path.join(
+                os.environ['MOZBUILD_STATE_PATH'],
+                os.path.basename(artifacts[i]).split('.')[0],
+            )
+            cli_common.utils.retry(lambda: download(artifact_url, target))
+
+
+def download(artifact_url, target):
+    # Download Taskcluster archive
+    resp = requests.get(artifact_url, stream=True)
+    resp.raise_for_status()
+
+    # Extract archive into destination
+    with tarfile.open(fileobj=io.BytesIO(resp.content)) as tar:
+        tar.extractall(target)

--- a/src/staticanalysis/bot/static_analysis_bot/infer/infer.py
+++ b/src/staticanalysis/bot/static_analysis_bot/infer/infer.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import subprocess
+
+from cli_common.log import get_logger
+from static_analysis_bot import Issue
+from static_analysis_bot import stats
+from static_analysis_bot.config import settings
+from static_analysis_bot.revisions import Revision
+
+logger = get_logger(__name__)
+
+ISSUE_MARKDOWN = '''
+## infer {type}
+
+- **Message**: {message}
+- **Location**: {location}
+- **In patch**: {in_patch}
+- **Clang check**: {check}
+- **Publishable check**: {publishable_check}
+- **Third Party**: {third_party}
+- **Expanded Macro**: {expanded_macro}
+- **Publishable **: {publishable}
+- **Is new**: {is_new}
+
+```
+{body}
+```
+'''
+
+INFER_SETUP_CMD = [
+    'gecko-env',
+    './mach', 'artifact', 'toolchain',
+    '--from-build', 'linux64-infer'
+]
+
+
+class Infer(object):
+    '''
+    Infer runner
+    '''
+    def __init__(self, validate_checks=True):
+        self.binary = os.path.join(
+            os.environ['MOZBUILD_STATE_PATH'],
+            'infer', 'infer', 'bin', 'infer',
+        )
+        assert os.path.exists(self.binary), \
+            'Missing infer in {}'.format(self.binary)
+
+    @stats.api.timed('runtime.infer')
+    def run(self, revision):
+        '''
+        Run modified files with specified checks through infer
+        using threaded workers (communicate through queues)
+        Output a list of InferIssue
+        '''
+        assert isinstance(revision, Revision)
+        self.revision = revision
+
+        # Run all files in a single command
+        # through mach static-analysis
+        cmd = [
+            'gecko-env',
+            './mach', '--log-no-times', 'static-analysis', 'check-java'
+        ] + list(revision.files)
+        logger.info('Running static-analysis', cmd=' '.join(cmd))
+
+        # Run command
+        try:
+            infer_output = subprocess.check_output(cmd, cwd=settings.repo_dir)
+        except subprocess.CalledProcessError as e:
+            logger.error('Mach static analysis failed: {}'.format(e.output))
+            raise
+
+        import json
+        report_file = os.path.join(settings.repo_dir, 'infer-out', 'report.json')
+        infer_output = json.load(open(report_file))
+        # Dump raw clang-tidy output as a Taskcluster artifact (for debugging)
+        infer_output_path = os.path.join(
+            settings.taskcluster_results_dir,
+            '{}-infer.txt'.format(repr(revision)),
+        )
+        with open(infer_output_path, 'w') as f:
+            f.write(json.dumps(infer_output, indent=2))
+        issues = self.parse_issues(infer_output, revision)
+        # Report stats for these issues
+        stats.report_issues('infer', issues)
+        return issues
+
+    def parse_issues(self, infer_output, revision):
+        '''
+        Parse infer output into structured issues
+        '''
+        if not infer_output:
+            logger.info('Infer could not generate any output.')
+            return []
+        # check if json is empty
+        nb_warnings = len(infer_output)
+        if not nb_warnings:
+            logger.info('Mach static analysis did not find any issue')
+            return []
+        logger.info('Mach static analysis found some issues', nb=nb_warnings)
+        return [InferIssue(issue, revision) for issue in infer_output]
+
+
+class InferIssue(Issue):
+    '''
+    An issue reported by infer
+    '''
+    def __init__(self, entry, revision):
+        assert isinstance(entry, dict)
+        assert not settings.repo_dir.endswith('/')
+        self.revision = revision
+        self.path = entry['file']
+        self.line = entry['line']
+        self.column = entry['column']
+        self.bug_type = entry['bug_type']
+        self.kind = entry['kind']
+        self.message = entry['qualifier']
+        self.body = None
+        self.nb_lines = 1
+
+    def __str__(self):
+        return '[{}] {} {}:{}'.format(self.bug_type, self.path,
+                                      self.line, self.column)
+
+    def build_extra_identifiers(self):
+        '''
+        Used to compare with same-class issues
+        '''
+        return {
+            'bug_type': self.bug_type,
+            'kind': self.kind,
+            'column': self.column,
+        }
+
+    def is_problem(self):
+        return self.kind in ('ERROR')
+
+    def validates(self):
+        '''
+        Publish infer issues all the time
+        '''
+        return True
+
+    def as_text(self):
+        '''
+        Build the text body published on reporters
+        '''
+        message = self.message
+        if len(message) > 0:
+            message = message[0].capitalize() + message[1:]
+        body = '{}: {} [infer: {}]'.format(self.kind, message, self.bug_type)
+        if self.body:
+            self.body += '\n{}'.format(body)
+        return body
+
+    def as_markdown(self):
+        return ISSUE_MARKDOWN.format(
+            check=self.bug_type,
+            message=self.message,
+            location='{}:{}:{}'.format(self.path, self.line, self.column),
+            body=self.body,
+            in_patch='yes' if self.revision.contains(self) else 'no',
+            publishable='yes' if self.is_publishable() else 'no',
+            is_new='yes' if self.is_new else 'no'
+        )
+
+    def as_diff(self):
+        '''
+        No diff available
+        '''
+
+    def as_dict(self):
+        '''
+        Outputs all available information into a serializable dict
+        '''
+        return {
+            'analyzer': 'infer',
+            'path': self.path,
+            'line': self.line,
+            'nb_lines': self.nb_lines,
+            'column': self.column,
+            'bug_type': self.bug_type,
+            'kind': self.kind,
+            'message': self.message,
+            'body': self.body,
+            'in_patch': self.revision.contains(self),
+            'is_new': self.is_new,
+            'validates': self.validates(),
+            'publishable': self.is_publishable(),
+        }

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -85,6 +85,18 @@ class Revision(object):
 
         return any(_is_clang(f) for f in self.files)
 
+    @property
+    def has_infer_files(self):
+        '''
+        Check if this revision has any file that might
+        be a Java file
+        '''
+        def _is_infer(filename):
+            _, ext = os.path.splitext(filename)
+            return ext.lower() in settings.java_extensions
+
+        return any(_is_infer(f) for f in self.files)
+
 
 class PhabricatorRevision(Revision):
     '''
@@ -96,6 +108,7 @@ class PhabricatorRevision(Revision):
         assert isinstance(api, PhabricatorAPI)
         self.api = api
 
+        print(description)
         # Parse Diff description
         match = self.regex.match(description)
         if match is None:

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -108,7 +108,6 @@ class PhabricatorRevision(Revision):
         assert isinstance(api, PhabricatorAPI)
         self.api = api
 
-        print(description)
         # Parse Diff description
         match = self.regex.match(description)
         if match is None:

--- a/src/staticanalysis/bot/static_analysis_bot/workflow.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflow.py
@@ -180,8 +180,8 @@ class Workflow(object):
                 else:
                     logger.info('Skip clang-format')
             if revision.has_infer_files:
-                with AndroidConfig(settings):
-                    if INFER in self.analyzers:
+                if INFER in self.analyzers:
+                    with AndroidConfig(settings):
                         analyzers.append(Infer)
                         logger.info('Setup Taskcluster infer build...')
                         setup_infer(self.index_service)
@@ -190,8 +190,8 @@ class Workflow(object):
                         logger.info('Mach configure for infer...')
                         run_check(['gecko-env', './mach', 'configure'],
                                   cwd=settings.repo_dir)
-                    else:
-                        logger.info('Skip infer')
+                else:
+                    logger.info('Skip infer')
             if not (revision.has_clang_files or revision.has_clang_files):
                 logger.info('No clang or java files detected, skipping mach, infer and clang-*')
 

--- a/src/staticanalysis/bot/static_analysis_bot/workflow.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflow.py
@@ -10,7 +10,6 @@ import os
 import subprocess
 from datetime import datetime
 from datetime import timedelta
-from shutil import copy
 
 import hglib
 
@@ -29,7 +28,7 @@ from static_analysis_bot.config import ARTIFACT_URL
 from static_analysis_bot.config import REPO_CENTRAL
 from static_analysis_bot.config import Publication
 from static_analysis_bot.config import settings
-from static_analysis_bot.infer import ANDROID_MOZCONFIG
+from static_analysis_bot.infer import AndroidConfig
 from static_analysis_bot.infer import setup as setup_infer
 from static_analysis_bot.infer.infer import Infer
 from static_analysis_bot.lint import MozLint
@@ -181,26 +180,18 @@ class Workflow(object):
                 else:
                     logger.info('Skip clang-format')
             if revision.has_infer_files:
-                # we copy the old mozconfig into the repository, so that we can
-                # enable the android build
-                android_mozconfig = os.path.join(settings.repo_dir, 'mozconfig')
-                copy(os.getenv('MOZCONFIG'), android_mozconfig)
-                os.environ['MOZCONFIG'] = android_mozconfig
-                subprocess.run(['chmod', 'u+w', android_mozconfig])
-                with open(android_mozconfig, 'a') as f:
-                    f.write(ANDROID_MOZCONFIG.format(
-                        mozbuild='/tmp/mozilla-state',
-                        openjdk=os.getenv('JAVA_HOME')))
-                if INFER in self.analyzers:
-                    analyzers.append(Infer)
-                    logger.info('Setup Taskcluster infer build...')
-                    setup_infer()
+                with AndroidConfig(settings):
+                    if INFER in self.analyzers:
+                        analyzers.append(Infer)
+                        logger.info('Setup Taskcluster infer build...')
+                        setup_infer(self.index_service)
 
-                    # Mach pre-setup with mozconfig
-                    logger.info('Mach configure for infer...')
-                    run_check(['gecko-env', './mach', 'configure'], cwd=settings.repo_dir)
-                else:
-                    logger.info('Skip infer')
+                        # Mach pre-setup with mozconfig
+                        logger.info('Mach configure for infer...')
+                        run_check(['gecko-env', './mach', 'configure'],
+                                  cwd=settings.repo_dir)
+                    else:
+                        logger.info('Skip infer')
             if not (revision.has_clang_files or revision.has_clang_files):
                 logger.info('No clang or java files detected, skipping mach, infer and clang-*')
 

--- a/src/staticanalysis/bot/static_analysis_bot/workflow.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflow.py
@@ -28,7 +28,6 @@ from static_analysis_bot.config import ARTIFACT_URL
 from static_analysis_bot.config import REPO_CENTRAL
 from static_analysis_bot.config import Publication
 from static_analysis_bot.config import settings
-from static_analysis_bot.infer import AndroidConfig
 from static_analysis_bot.infer import setup as setup_infer
 from static_analysis_bot.infer.infer import Infer
 from static_analysis_bot.lint import MozLint
@@ -181,15 +180,9 @@ class Workflow(object):
                     logger.info('Skip clang-format')
             if revision.has_infer_files:
                 if INFER in self.analyzers:
-                    with AndroidConfig(settings):
-                        analyzers.append(Infer)
-                        logger.info('Setup Taskcluster infer build...')
-                        setup_infer(self.index_service)
-
-                        # Mach pre-setup with mozconfig
-                        logger.info('Mach configure for infer...')
-                        run_check(['gecko-env', './mach', 'configure'],
-                                  cwd=settings.repo_dir)
+                    analyzers.append(Infer)
+                    logger.info('Setup Taskcluster infer build...')
+                    setup_infer(self.index_service)
                 else:
                     logger.info('Skip infer')
             if not (revision.has_clang_files or revision.has_clang_files):

--- a/src/staticanalysis/bot/tests/conftest.py
+++ b/src/staticanalysis/bot/tests/conftest.py
@@ -474,3 +474,49 @@ def mock_clang_repeats(mock_config):
     path = os.path.join(MOCK_DIR, 'clang-repeats.txt')
     with open(path) as f:
         return f.read().replace('{REPO}', mock_config.repo_dir)
+
+
+@pytest.fixture
+def mock_infer(tmpdir, monkeypatch):
+    # Create a temp mozbuild path
+    infer_dir = tmpdir.mkdir('infer').mkdir('infer').mkdir('bin')
+    os.environ['MOZBUILD_STATE_PATH'] = str(tmpdir.realpath())
+
+    open(str(infer_dir.join('infer').realpath()), 'w+')
+
+
+@pytest.fixture
+def mock_infer_output():
+    '''
+    Load a real case clang output
+    '''
+    path = os.path.join(MOCK_DIR, 'infer-output.txt')
+    with open(path) as f:
+        return f.read()
+
+
+@pytest.fixture
+def mock_infer_issues():
+    '''
+    Load parsed issues from a real case (above)
+    '''
+    path = os.path.join(MOCK_DIR, 'infer-issues.txt')
+    with open(path) as f:
+        return f.read()
+
+
+@pytest.fixture
+def mock_infer_repeats(mock_config):
+    '''
+    Load parsed issues with repeated issues
+    '''
+    # Write dummy test_repeat.cpp file in repo
+    # Needed to build line hash
+    test_java = os.path.join(mock_config.repo_dir, 'test_repeats.java')
+    with open(test_java, 'w') as f:
+        for i in range(5):
+            f.write('line {}\n'.format(i))
+
+    path = os.path.join(MOCK_DIR, 'infer-repeats.txt')
+    with open(path) as f:
+        return f.read().replace('{REPO}', mock_config.repo_dir)

--- a/src/staticanalysis/bot/tests/mocks/infer-issues.txt
+++ b/src/staticanalysis/bot/tests/mocks/infer-issues.txt
@@ -1,0 +1,12 @@
+ERROR: Object returned by `getRootException(e)` could be null and is dereferenced by call to `getExceptionStackTrace(...)` at line 268. [infer: NULL_DEREFERENCE]
+--------------------
+ERROR: Object `s` last assigned on line 612 could be null and is dereferenced at line 613. [infer: NULL_DEREFERENCE]
+--------------------
+ERROR: Object `sections` last assigned on line 804 could be null and is dereferenced at line 805. [infer: NULL_DEREFERENCE]
+--------------------
+ERROR: Object returned by `get(getApplicationContext()).getDir()` could be null and is dereferenced at line 1348. [infer: NULL_DEREFERENCE]
+--------------------
+ERROR: Resource of type `java.io.PipedOutputStream` acquired by call to `PipedOutputStream()` at line 1763 is not released after line 1766. [infer: RESOURCE_LEAK]
+--------------------
+ERROR: Resource of type `java.io.PipedOutputStream` acquired to `output` by call to `PipedOutputStream()` at line 1763 is not released after line 1778.
+**Note**: potential exception at line 1764 [infer: RESOURCE_LEAK]

--- a/src/staticanalysis/bot/tests/mocks/infer-output.txt
+++ b/src/staticanalysis/bot/tests/mocks/infer-output.txt
@@ -1,0 +1,891 @@
+[
+  {
+    "bug_class": "PROVER",
+    "kind": "ERROR",
+    "bug_type": "NULL_DEREFERENCE",
+    "qualifier": "object returned by `getRootException(e)` could be null and is dereferenced by call to `getExceptionStackTrace(...)` at line 268.",
+    "severity": "HIGH",
+    "visibility": "user",
+    "line": 268,
+    "column": -1,
+    "procedure": "String GeckoAppShell.getExceptionStackTrace(Throwable)",
+    "procedure_id": "org.mozilla.gecko.GeckoAppShell.getExceptionStackTrace(java.lang.Throwable):java.lang.String.2579b77f3c527fd0e244a558ee700ea0",
+    "procedure_start_line": 268,
+    "file": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+    "bug_trace": [
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 268,
+        "column_number": -1,
+        "description": "start of procedure getExceptionStackTrace(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 55,
+        "column_number": -1,
+        "description": "start of procedure getRootException(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 56,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 59,
+        "column_number": -1,
+        "description": "return from a call to Throwable CrashHandler.getRootException(Throwable)"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 268,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 68,
+        "column_number": -1,
+        "description": "start of procedure getExceptionStackTrace(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 69,
+        "column_number": -1,
+        "description": "Skipping StringWriter(): unknown method"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 70,
+        "column_number": -1,
+        "description": "Skipping PrintWriter(...): unknown method"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 71,
+        "column_number": -1,
+        "description": "Skipping printStackTrace(...): unknown method"
+      }
+    ],
+    "key": "GeckoAppShell.java|getExceptionStackTrace|NULL_DEREFERENCE",
+    "node_key": "d6170fb5d3d229077ee51eb7960a81a2",
+    "hash": "a49d2c1c6af1cab755faffd802a791c8",
+    "bug_type_hum": "Null Dereference",
+    "censored_reason": ""
+  },
+  {
+    "bug_class": "PROVER",
+    "kind": "ERROR",
+    "bug_type": "NULL_DEREFERENCE",
+    "qualifier": "object `s` last assigned on line 612 could be null and is dereferenced at line 613.",
+    "severity": "HIGH",
+    "visibility": "user",
+    "line": 613,
+    "column": -1,
+    "procedure": "SensorEventListener GeckoAppShell.getSensorListener()",
+    "procedure_id": "org.mozilla.gecko.GeckoAppShell.getSensorListener():android.hardware.SensorEventListener.c50665c1ac070a355656f674d5c14bd8",
+    "procedure_start_line": 611,
+    "file": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+    "bug_trace": [
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 611,
+        "column_number": -1,
+        "description": "start of procedure getSensorListener()"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 612,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 613,
+        "column_number": -1,
+        "description": ""
+      }
+    ],
+    "key": "GeckoAppShell.java|getSensorListener|NULL_DEREFERENCE",
+    "node_key": "c8c6b1f0f8892a67c957e59c27c08c9f",
+    "hash": "161f56518072d3bcec0714bef1c7ad32",
+    "bug_type_hum": "Null Dereference",
+    "censored_reason": ""
+  },
+  {
+    "bug_class": "PROVER",
+    "kind": "ERROR",
+    "bug_type": "NULL_DEREFERENCE",
+    "qualifier": "object `sections` last assigned on line 804 could be null and is dereferenced at line 805.",
+    "severity": "HIGH",
+    "visibility": "user",
+    "line": 805,
+    "column": -1,
+    "procedure": "boolean GeckoProfile.remove()",
+    "procedure_id": "org.mozilla.gecko.GeckoProfile.remove():boolean.586c92fcbaebfcd95237c73fdce93342",
+    "procedure_start_line": 776,
+    "file": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+    "bug_trace": [
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 776,
+        "column_number": -1,
+        "description": "start of procedure remove()"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 778,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 779,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 783,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 369,
+        "column_number": -1,
+        "description": "start of procedure isCustomProfile()"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 370,
+        "column_number": -1,
+        "description": "return from a call to boolean GeckoProfile.isCustomProfile()"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 783,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 792,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 877,
+        "column_number": -1,
+        "description": "start of procedure findProfileDir()"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 878,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 369,
+        "column_number": -1,
+        "description": "start of procedure isCustomProfile()"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 370,
+        "column_number": -1,
+        "description": "return from a call to boolean GeckoProfile.isCustomProfile()"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 878,
+        "column_number": -1,
+        "description": "Taking true branch"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 879,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 881,
+        "column_number": -1,
+        "description": "return from a call to File GeckoProfile.findProfileDir()"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 793,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 801,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 803,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfileDirectories.java",
+        "line_number": 80,
+        "column_number": -1,
+        "description": "start of procedure getProfilesINI(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfileDirectories.java",
+        "line_number": 81,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 26,
+        "column_number": -1,
+        "description": "start of procedure INIParser(...)"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 27,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INISection.java",
+        "line_number": 31,
+        "column_number": -1,
+        "description": "start of procedure INISection(...)"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INISection.java",
+        "line_number": 32,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INISection.java",
+        "line_number": 33,
+        "column_number": -1,
+        "description": "return from a call to INISection.<init>(String)"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 28,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 29,
+        "column_number": -1,
+        "description": "return from a call to INIParser.<init>(File)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfileDirectories.java",
+        "line_number": 81,
+        "column_number": -1,
+        "description": "return from a call to INIParser GeckoProfileDirectories.getProfilesINI(File)"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 804,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 72,
+        "column_number": -1,
+        "description": "start of procedure getSections()"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 73,
+        "column_number": -1,
+        "description": "Taking true branch"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 75,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 86,
+        "column_number": -1,
+        "description": "start of procedure parse()"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INISection.java",
+        "line_number": 79,
+        "column_number": -1,
+        "description": "start of procedure parse()"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INISection.java",
+        "line_number": 80,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INISection.java",
+        "line_number": 81,
+        "column_number": -1,
+        "description": "return from a call to void INISection.parse()"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 87,
+        "column_number": -1,
+        "description": "Skipping parse(...): empty list of specs"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 91,
+        "column_number": -1,
+        "description": "Definition of parse(...)"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 88,
+        "column_number": -1,
+        "description": "return from a call to void INIParser.parse()"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/INIParser.java",
+        "line_number": 80,
+        "column_number": -1,
+        "description": "return from a call to Hashtable INIParser.getSections()"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 805,
+        "column_number": -1,
+        "description": ""
+      }
+    ],
+    "key": "GeckoProfile.java|remove|NULL_DEREFERENCE",
+    "node_key": "42f56fda1ad408e362508b93a175bb0c",
+    "hash": "975f24b20b13b92a016c84e2c57c0cb1",
+    "bug_type_hum": "Null Dereference",
+    "censored_reason": ""
+  },
+  {
+    "bug_class": "PROVER",
+    "kind": "ERROR",
+    "bug_type": "NULL_DEREFERENCE",
+    "qualifier": "object returned by `get(getApplicationContext()).getDir()` could be null and is dereferenced at line 1348.",
+    "severity": "HIGH",
+    "visibility": "user",
+    "line": 1348,
+    "column": -1,
+    "procedure": "void GeckoAppShell.listOfOpenFiles()",
+    "procedure_id": "org.mozilla.gecko.GeckoAppShell.listOfOpenFiles():void.e65a15945c13343ed22089b938036047",
+    "procedure_start_line": 1339,
+    "file": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+    "bug_trace": [
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1339,
+        "column_number": -1,
+        "description": "start of procedure listOfOpenFiles()"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1340,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1341,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1344,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1345,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1346,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1348,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1468,
+        "column_number": -1,
+        "description": "start of procedure getApplicationContext()"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1469,
+        "column_number": -1,
+        "description": "return from a call to Context GeckoAppShell.getApplicationContext()"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1348,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 175,
+        "column_number": -1,
+        "description": "start of procedure get(...)"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 202,
+        "column_number": -1,
+        "description": "Definition of get(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 175,
+        "column_number": -1,
+        "description": "return from a call to GeckoProfile GeckoProfile.get(Context)"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1348,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 395,
+        "column_number": -1,
+        "description": "start of procedure getDir()"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 396,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 404,
+        "column_number": -1,
+        "description": "start of procedure forceCreateLocked()"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 405,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 412,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 877,
+        "column_number": -1,
+        "description": "start of procedure findProfileDir()"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 878,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 4,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 369,
+        "column_number": -1,
+        "description": "start of procedure isCustomProfile()"
+      },
+      {
+        "level": 4,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 370,
+        "column_number": -1,
+        "description": "return from a call to boolean GeckoProfile.isCustomProfile()"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 878,
+        "column_number": -1,
+        "description": "Taking true branch"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 879,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 881,
+        "column_number": -1,
+        "description": "return from a call to File GeckoProfile.findProfileDir()"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 412,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 413,
+        "column_number": -1,
+        "description": "Skipping d(...): unknown method"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 421,
+        "column_number": -1,
+        "description": "return from a call to void GeckoProfile.forceCreateLocked()"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoProfile.java",
+        "line_number": 397,
+        "column_number": -1,
+        "description": "return from a call to File GeckoProfile.getDir()"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1348,
+        "column_number": -1,
+        "description": ""
+      }
+    ],
+    "key": "GeckoAppShell.java|listOfOpenFiles|NULL_DEREFERENCE",
+    "node_key": "21bbf00bf52cbb29c85ade37dbbc751f",
+    "hash": "48a851cfb89fce946731aea6c30b121c",
+    "bug_type_hum": "Null Dereference",
+    "censored_reason": ""
+  },
+  {
+    "bug_class": "PROVER",
+    "kind": "ERROR",
+    "bug_type": "RESOURCE_LEAK",
+    "qualifier": "resource of type `java.io.PipedOutputStream` acquired by call to `PipedOutputStream()` at line 1763 is not released after line 1766.",
+    "severity": "HIGH",
+    "visibility": "user",
+    "line": 1766,
+    "column": -1,
+    "procedure": "int GeckoAppShell$BitmapConnection$BitmapInputStream.read(byte[],int,int)",
+    "procedure_id": "org.mozilla.gecko.GeckoAppShell$BitmapConnection$BitmapInputStream.read(byte[],int,int):int.682c283a50c0818ed831dc9435df8e1d",
+    "procedure_start_line": 1757,
+    "file": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+    "bug_trace": [
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1757,
+        "column_number": -1,
+        "description": "start of procedure read(...)"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1759,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1763,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1764,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1766,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1577,
+        "column_number": -1,
+        "description": "start of procedure GeckoAppShell$BitmapConnection$BitmapInputStream$1(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1767,
+        "column_number": -1,
+        "description": "return from a call to GeckoAppShell$BitmapConnection$BitmapInputStream$1.<init>(GeckoAppShell$BitmapConnection$BitmapInputStream,PipedOutputStream)"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1766,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/ThreadUtils.java",
+        "line_number": 114,
+        "column_number": -1,
+        "description": "start of procedure postToBackgroundThread(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/ThreadUtils.java",
+        "line_number": 115,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/GeckoBackgroundThread.java",
+        "line_number": 69,
+        "column_number": -1,
+        "description": "start of procedure post(...)"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/GeckoBackgroundThread.java",
+        "line_number": 70,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/GeckoBackgroundThread.java",
+        "line_number": 74,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/GeckoBackgroundThread.java",
+        "line_number": 55,
+        "column_number": -1,
+        "description": "start of procedure getHandler()"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/GeckoBackgroundThread.java",
+        "line_number": 56,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/GeckoBackgroundThread.java",
+        "line_number": 60,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 3,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/GeckoBackgroundThread.java",
+        "line_number": 66,
+        "column_number": -1,
+        "description": "return from a call to Handler GeckoBackgroundThread.getHandler()"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/GeckoBackgroundThread.java",
+        "line_number": 74,
+        "column_number": -1,
+        "description": "Skipping post(...): unknown method"
+      },
+      {
+        "level": 2,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/GeckoBackgroundThread.java",
+        "line_number": 75,
+        "column_number": -1,
+        "description": "return from a call to void GeckoBackgroundThread.post(Runnable)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/ThreadUtils.java",
+        "line_number": 116,
+        "column_number": -1,
+        "description": "return from a call to void ThreadUtils.postToBackgroundThread(GeckoAppShell$BitmapConnection$BitmapInputStream$1)"
+      }
+    ],
+    "key": "GeckoAppShell.java|read|RESOURCE_LEAK",
+    "node_key": "71139e4a061ea1b2814b8b6c39dedd41",
+    "hash": "65557953242925a574fe001a08cec8c6",
+    "bug_type_hum": "Resource Leak",
+    "censored_reason": ""
+  },
+  {
+    "bug_class": "PROVER",
+    "kind": "ERROR",
+    "bug_type": "RESOURCE_LEAK",
+    "qualifier": "resource of type `java.io.PipedOutputStream` acquired to `output` by call to `PipedOutputStream()` at line 1763 is not released after line 1778.\n**Note**: potential exception at line 1764",
+    "severity": "HIGH",
+    "visibility": "user",
+    "line": 1778,
+    "column": -1,
+    "procedure": "int GeckoAppShell$BitmapConnection$BitmapInputStream.read(byte[],int,int)",
+    "procedure_id": "org.mozilla.gecko.GeckoAppShell$BitmapConnection$BitmapInputStream.read(byte[],int,int):int.682c283a50c0818ed831dc9435df8e1d",
+    "procedure_start_line": 1757,
+    "file": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+    "bug_trace": [
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1757,
+        "column_number": -1,
+        "description": "start of procedure read(...)"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1759,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1763,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1764,
+        "column_number": -1,
+        "description": "exception java.io.IOException"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 1778,
+        "column_number": -1,
+        "description": ""
+      }
+    ],
+    "key": "GeckoAppShell.java|read|RESOURCE_LEAK",
+    "node_key": "48815eab4c26cee962db00712b67bbd0",
+    "hash": "e8f45c41ef8c30863aaa1ad6273e90bc",
+    "bug_type_hum": "Resource Leak",
+    "censored_reason": ""
+  }
+]

--- a/src/staticanalysis/bot/tests/mocks/infer-repeats.txt
+++ b/src/staticanalysis/bot/tests/mocks/infer-repeats.txt
@@ -1,0 +1,170 @@
+[
+  {
+    "bug_class": "PROVER",
+    "kind": "ERROR",
+    "bug_type": "NULL_DEREFERENCE",
+    "qualifier": "object returned by `getRootException(e)` could be null and is dereferenced by call to `getExceptionStackTrace(...)` at line 268.",
+    "severity": "HIGH",
+    "visibility": "user",
+    "line": 268,
+    "column": -1,
+    "procedure": "String GeckoAppShell.getExceptionStackTrace(Throwable)",
+    "procedure_id": "org.mozilla.gecko.GeckoAppShell.getExceptionStackTrace(java.lang.Throwable):java.lang.String.2579b77f3c527fd0e244a558ee700ea0",
+    "procedure_start_line": 268,
+    "file": "{REPO}/test_repeats.java",
+    "bug_trace": [
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 268,
+        "column_number": -1,
+        "description": "start of procedure getExceptionStackTrace(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 55,
+        "column_number": -1,
+        "description": "start of procedure getRootException(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 56,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 59,
+        "column_number": -1,
+        "description": "return from a call to Throwable CrashHandler.getRootException(Throwable)"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 268,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 68,
+        "column_number": -1,
+        "description": "start of procedure getExceptionStackTrace(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 69,
+        "column_number": -1,
+        "description": "Skipping StringWriter(): unknown method"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 70,
+        "column_number": -1,
+        "description": "Skipping PrintWriter(...): unknown method"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 71,
+        "column_number": -1,
+        "description": "Skipping printStackTrace(...): unknown method"
+      }
+    ],
+    "key": "GeckoAppShell.java|getExceptionStackTrace|NULL_DEREFERENCE",
+    "node_key": "d6170fb5d3d229077ee51eb7960a81a2",
+    "hash": "a49d2c1c6af1cab755faffd802a791c8",
+    "bug_type_hum": "Null Dereference",
+    "censored_reason": ""
+  },
+  {
+    "bug_class": "PROVER",
+    "kind": "ERROR",
+    "bug_type": "NULL_DEREFERENCE",
+    "qualifier": "object returned by `getRootException(e)` could be null and is dereferenced by call to `getExceptionStackTrace(...)` at line 268.",
+    "severity": "HIGH",
+    "visibility": "user",
+    "line": 268,
+    "column": -1,
+    "procedure": "String GeckoAppShell.getExceptionStackTrace(Throwable)",
+    "procedure_id": "org.mozilla.gecko.GeckoAppShell.getExceptionStackTrace(java.lang.Throwable):java.lang.String.2579b77f3c527fd0e244a558ee700ea0",
+    "procedure_start_line": 268,
+    "file": "{REPO}/test_repeats.java",
+    "bug_trace": [
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 268,
+        "column_number": -1,
+        "description": "start of procedure getExceptionStackTrace(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 55,
+        "column_number": -1,
+        "description": "start of procedure getRootException(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 56,
+        "column_number": -1,
+        "description": "Taking false branch"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 59,
+        "column_number": -1,
+        "description": "return from a call to Throwable CrashHandler.getRootException(Throwable)"
+      },
+      {
+        "level": 0,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/GeckoAppShell.java",
+        "line_number": 268,
+        "column_number": -1,
+        "description": ""
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 68,
+        "column_number": -1,
+        "description": "start of procedure getExceptionStackTrace(...)"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 69,
+        "column_number": -1,
+        "description": "Skipping StringWriter(): unknown method"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 70,
+        "column_number": -1,
+        "description": "Skipping PrintWriter(...): unknown method"
+      },
+      {
+        "level": 1,
+        "filename": "mobile/android/geckoview/src/main/java/org/mozilla/gecko/CrashHandler.java",
+        "line_number": 71,
+        "column_number": -1,
+        "description": "Skipping printStackTrace(...): unknown method"
+      }
+    ],
+    "key": "GeckoAppShell.java|getExceptionStackTrace|NULL_DEREFERENCE",
+    "node_key": "d6170fb5d3d229077ee51eb7960a81a2",
+    "hash": "a49d2c1c6af1cab755faffd802a791c8",
+    "bug_type_hum": "Null Dereference",
+    "censored_reason": ""
+  }
+]

--- a/src/staticanalysis/bot/tests/test_infer.py
+++ b/src/staticanalysis/bot/tests/test_infer.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+import json
+from collections import Counter
+
+BAD_JAVA_INFER = '''public class bad {
+  public void x() {
+    String x = null;
+    x.length();
+  }
+}
+'''
+
+
+def test_infer_parser(mock_config, mock_repository, mock_revision, mock_infer, mock_infer_output, mock_infer_issues):
+    '''
+    Test the infer (or mach static-analysis) parser
+    '''
+    from static_analysis_bot.infer.infer import Infer
+    infer = Infer()
+
+    # Empty Output, infer maybe failed
+    infer_output = {}
+    issues = infer.parse_issues(infer_output, mock_revision)
+    assert issues == []
+
+    # No issues
+    infer_output = json.loads('[]')
+    issues = infer.parse_issues(infer_output, mock_revision)
+    assert issues == []
+
+    # Real case
+    issues = infer.parse_issues(json.loads(mock_infer_output), mock_revision)
+    assert len(issues) == 6
+    sep = '\n' + '-'*20 + '\n'
+    summary = sep.join(issue.as_text() for issue in issues)
+    summary.strip()
+    assert summary == mock_infer_issues
+
+
+def test_as_text(mock_revision):
+    '''
+    Test text export for InferIssue
+    '''
+    from static_analysis_bot.infer.infer import InferIssue
+    parts = {
+        'file': 'path/to/file.java',
+        'line': 3,
+        'column': -1,
+        'bug_type': 'SOMETYPE',
+        'kind': 'SomeKindOfBug',
+        'qualifier': 'Error on this line'
+    }
+    issue = InferIssue(parts, mock_revision)
+    issue.body = 'Dummy body withUppercaseChars'
+
+    expected = 'SomeKindOfBug: Error on this line [infer: SOMETYPE]'
+    assert issue.as_text() == expected
+
+
+def test_as_markdown(mock_revision):
+    '''
+    Test markdown generation for InferIssue
+    '''
+    from static_analysis_bot.infer.infer import InferIssue
+    parts = {
+        'file': 'path/to/file.java',
+        'line': 3,
+        'column': -1,
+        'bug_type': 'SOMETYPE',
+        'kind': 'SomeKindOfBug',
+        'qualifier': 'Error on this line'
+    }
+    issue = InferIssue(parts, mock_revision)
+    issue.body = 'Dummy body'
+
+    assert issue.as_markdown() == '''
+## infer error
+
+- **Message**: Error on this line
+- **Location**: path/to/file.java:3:-1
+- **In patch**: no
+- **Infer check**: SOMETYPE
+- **Publishable **: no
+- **Is new**: no
+
+```
+Dummy body
+```
+'''
+
+
+def test_repeats(mock_infer, mock_infer_repeats, mock_revision, mock_config):
+    '''
+    Test repeated issues are removed through set usage
+    '''
+
+    from static_analysis_bot.infer.infer import Infer
+    infer = Infer()
+
+    issues = infer.parse_issues(json.loads(mock_infer_repeats), mock_revision)
+    assert isinstance(issues, list)
+
+    # We have 2 issues
+    assert len(issues) == 2
+    count = Counter(i.bug_type for i in issues)
+    assert count['NULL_DEREFERENCE'] == 2
+
+    # A set should remove repeats
+    issues = set(issues)
+    assert len(issues) == 1
+    count = Counter(i.bug_type for i in issues)
+    assert count['NULL_DEREFERENCE'] == 1


### PR DESCRIPTION
This introduces `infer` into the static-analysis bot. When a `.java` file is part of a revision, it is passed to the `./mach static-analysis check-java` command.