### PR TITLE
uplift/bot: Cancel uplift requests when merging fails.

### DIFF
--- a/src/uplift/backend/uplift_backend/api.yml
+++ b/src/uplift/backend/uplift_backend/api.yml
@@ -92,7 +92,7 @@ paths:
       parameters:
       - name: bugzilla_id
         in: path
-        description: Bugzilla ID of the Bug to delete
+        description: Bugzilla ID of the Bug to update
         required: true
         type: integer
       responses:

--- a/src/uplift/bot/requirements.nix
+++ b/src/uplift/bot/requirements.nix
@@ -877,8 +877,8 @@ let
     };
 
     "libmozdata" = python.mkDerivation {
-      name = "libmozdata-0.1.40";
-      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/db/6a/4ac82bfd34d6146916adee37736c97d199312d5c626a3835440ff6003069/libmozdata-0.1.40.tar.gz"; sha256 = "abc47ce6797ffe7764fb416f55f8da2c2a9d570140472934d0c6b9af6d84e2f8"; };
+      name = "libmozdata-0.1.43";
+      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/b2/6e/9910883d2f964cbdedcee9ae6cc0fd07c93911c75073595d97f1b865ee90/libmozdata-0.1.43.tar.gz"; sha256 = "2010fcb61de7f9c82a261100b2575f4045d2592a227d0bf4f1d051d2e96077ab"; };
       doCheck = commonDoCheck;
       checkPhase = "";
       installCheckPhase = "";
@@ -897,7 +897,7 @@ let
     ];
       meta = with pkgs.stdenv.lib; {
         homepage = "https://github.com/mozilla/libmozdata";
-        license = "MPL2";
+        license = licenses.mpl20;
         description = "Library to access and aggregate several Mozilla data sources.";
       };
     };

--- a/src/uplift/bot/requirements_frozen.txt
+++ b/src/uplift/bot/requirements_frozen.txt
@@ -42,7 +42,7 @@ ipython-genutils==0.2.0
 isort==4.3.4
 jedi==0.12.1
 jmespath==0.9.3
-libmozdata==0.1.40
+libmozdata==0.1.43
 Logbook==1.4.0
 mccabe==0.6.1
 mohawk==0.3.4

--- a/src/uplift/bot/uplift_bot/bugzilla.py
+++ b/src/uplift/bot/uplift_bot/bugzilla.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from libmozdata.bugzilla import Bugzilla
+from libmozdata.bugzilla import BugzillaUser
+
+
+def use_bugzilla(bugzilla_url, bugzilla_token=None):
+    '''
+    Configure Bugzilla access (URL + token)
+    '''
+    # Patch libmozdata configuration
+    # TODO: Fix config calls in libmozdata
+    # os.environ['LIBMOZDATA_CFG_BUGZILLA_URL'] = bugzilla_url
+    # set_config(ConfigEnv())
+    Bugzilla.URL = bugzilla_url
+    Bugzilla.API_URL = bugzilla_url + '/rest/bug'
+    Bugzilla.ATTACHMENT_API_URL = Bugzilla.API_URL + '/attachment'
+    BugzillaUser.URL = bugzilla_url
+    BugzillaUser.API_URL = bugzilla_url + '/rest/user'
+    if bugzilla_token is not None:
+        Bugzilla.TOKEN = bugzilla_token
+        BugzillaUser.TOKEN = bugzilla_token
+
+
+def list_bugs(query):
+    '''
+    List all the bugs from a Bugzilla query
+    '''
+    def _bughandler(bug, data):
+        bugid = bug['id']
+        data[bugid] = bug
+
+    def _attachmenthandler(attachments, bugid, data):
+        data[int(bugid)] = attachments
+
+    bugs, attachments = {}, {}
+
+    bz = Bugzilla(query,
+                  bughandler=_bughandler,
+                  attachmenthandler=_attachmenthandler,
+                  bugdata=bugs,
+                  attachmentdata=attachments)
+    bz.get_data().wait()
+
+    # Map attachments on bugs
+    for bugid, _attachments in attachments.items():
+        if bugid not in bugs:
+            continue
+        bugs[bugid]['attachments'] = _attachments
+
+    return bugs
+
+
+def load_users(analysis):
+    '''
+    Load users linked through roles to an analysis
+    '''
+    assert analysis is not None, \
+        'Missing bug analysis'
+
+    roles = {}
+
+    def _extract_user(user_data, role):
+        # Support multiple input structures
+        if user_data is None:
+            return
+        elif isinstance(user_data, dict):
+            if 'id' in user_data:
+                key = user_data['id']
+            elif 'email' in user_data:
+                key = user_data['email']
+            else:
+                raise Exception('Invalid user data : no id or email')
+
+        elif isinstance(user_data, str):
+            key = user_data
+        else:
+            raise Exception('Invalid user data : unsupported format')
+
+        if key not in roles:
+            roles[key] = []
+        roles[key].append(role)
+
+    # Extract users keys & roles
+    _extract_user(analysis['users'].get('creator'), 'creator')
+    _extract_user(analysis['users'].get('assignee'), 'assignee')
+    for r in analysis['users']['reviewers']:
+        _extract_user(r, 'reviewer')
+    _extract_user(analysis['uplift_author'], 'uplift_author')
+
+    def _handler(user, data):
+        # Store users with their roles
+        user['roles'] = roles.get(user['id'], roles.get(user['email'], []))
+        data.append(user)
+
+    # Finally fetch clean users data through Bugzilla
+    out = []
+    BugzillaUser(user_names=roles.keys(),
+                 user_handler=_handler,
+                 user_data=out).wait()
+    return out

--- a/src/uplift/bot/uplift_bot/cli.py
+++ b/src/uplift/bot/uplift_bot/cli.py
@@ -37,12 +37,14 @@ def main(bugzilla_id,
                           required=(
                               'BUGZILLA_URL',
                               'BUGZILLA_TOKEN',
+                              'BUGZILLA_READ_ONLY',
                               'API_URL',
                               'APP_CHANNEL',
                               'UPLIFT_NOTIFICATIONS',
                           ),
                           existing=dict(
                               APP_CHANNEL='development',
+                              BUGZILLA_READ_ONLY='true',
                               UPLIFT_NOTIFICATIONS=['babadie@mozilla.com'],
                           ),
                           taskcluster_client_id=taskcluster_client_id,
@@ -68,6 +70,7 @@ def main(bugzilla_id,
     bot.use_bugzilla(
         secrets['BUGZILLA_URL'],
         secrets['BUGZILLA_TOKEN'],
+        bool(secrets['BUGZILLA_READ_ONLY']),
     )
     bot.use_cache(cache_root)
     if bugzilla_id:

--- a/src/uplift/bot/uplift_bot/cli.py
+++ b/src/uplift/bot/uplift_bot/cli.py
@@ -44,7 +44,7 @@ def main(bugzilla_id,
                           ),
                           existing=dict(
                               APP_CHANNEL='development',
-                              BUGZILLA_READ_ONLY='true',
+                              BUGZILLA_READ_ONLY=True,
                               UPLIFT_NOTIFICATIONS=['babadie@mozilla.com'],
                           ),
                           taskcluster_client_id=taskcluster_client_id,
@@ -70,7 +70,7 @@ def main(bugzilla_id,
     bot.use_bugzilla(
         secrets['BUGZILLA_URL'],
         secrets['BUGZILLA_TOKEN'],
-        bool(secrets['BUGZILLA_READ_ONLY']),
+        secrets['BUGZILLA_READ_ONLY'],
     )
     bot.use_cache(cache_root)
     if bugzilla_id:

--- a/src/uplift/bot/uplift_bot/merge.py
+++ b/src/uplift/bot/uplift_bot/merge.py
@@ -137,12 +137,13 @@ class MergeTest(object):
         Store a new patch status on backend
         '''
         assert isinstance(result, MergeResult)
+        parent = result.parent.decode('utf-8') if isinstance(result.parent, bytes) else result.parent
 
         # Publish as a new patch status
         data = {
             'group': self.group,
             'revision': revision.decode('utf-8'),
-            'revision_parent': result.parent,
+            'revision_parent': parent,
             'status': result.status,
             'branch': self.branch.decode('utf-8'),
             'message': result.message,

--- a/src/uplift/bot/uplift_bot/sync.py
+++ b/src/uplift/bot/uplift_bot/sync.py
@@ -177,8 +177,9 @@ class Bot(object):
         self.bugs = {}
         self.repository = None
         self.bugzilla_url = bugzilla_url
+        self.bugzilla_read_only = read_only
 
-        use_bugzilla(bugzilla_url, bugzilla_token, read_only)
+        use_bugzilla(bugzilla_url, bugzilla_token)
         logger.info('Use bugzilla server', url=self.bugzilla_url)
 
     def use_cache(self, cache_root):
@@ -324,7 +325,7 @@ class Bot(object):
         # Save invalid merge in report, and cancel the uplift request
         if not merge_test.is_valid():
             self.report.add_invalid_merge(merge_test)
-            cancel_uplift_request(merge_test)
+            cancel_uplift_request(merge_test, self.bugzilla_read_only)
 
     def delete_bug(self, sync):
         '''

--- a/src/uplift/bot/uplift_bot/sync.py
+++ b/src/uplift/bot/uplift_bot/sync.py
@@ -13,6 +13,7 @@ from libmozdata.patchanalysis import parse_uplift_comment
 from cli_common.log import get_logger
 from uplift_bot.api import NotFound
 from uplift_bot.api import api_client
+from uplift_bot.bugzilla import cancel_uplift_request
 from uplift_bot.bugzilla import list_bugs
 from uplift_bot.bugzilla import load_users
 from uplift_bot.bugzilla import use_bugzilla
@@ -169,7 +170,7 @@ class Bot(object):
         # Init report
         self.report = Report(notification_emails)
 
-    def use_bugzilla(self, bugzilla_url, bugzilla_token=None):
+    def use_bugzilla(self, bugzilla_url, bugzilla_token=None, read_only=True):
         '''
         Setup bugzilla usage (url + token)
         '''
@@ -177,7 +178,7 @@ class Bot(object):
         self.repository = None
         self.bugzilla_url = bugzilla_url
 
-        use_bugzilla(bugzilla_url, bugzilla_token)
+        use_bugzilla(bugzilla_url, bugzilla_token, read_only)
         logger.info('Use bugzilla server', url=self.bugzilla_url)
 
     def use_cache(self, cache_root):
@@ -320,9 +321,10 @@ class Bot(object):
         # Always cleanup
         self.repository.cleanup()
 
-        # Save invalid merge in report
+        # Save invalid merge in report, and cancel the uplift request
         if not merge_test.is_valid():
             self.report.add_invalid_merge(merge_test)
+            cancel_uplift_request(merge_test)
 
     def delete_bug(self, sync):
         '''


### PR DESCRIPTION
When a Firefox patch is requested be uplifted, but it doesn't apply cleanly, we:
1. Remove the "approval-mozilla-{beta,release,esr*}" flag from attachments
2. Post a comment explaining that the merge failed, with details
3. Needinfo the person who requested the uplift

TODO:

- [x] Use a custom Bugzilla token to update bugs as [Uplift Bot [:upliftbot]](https://bugzilla.mozilla.org/user_profile?login=upliftbot%40mozilla.com)
- [x] Add a setting to disable bug editing