### PR TITLE
[shipit] Fix setting a revision manually.

### DIFF
--- a/src/shipit/frontend/src/views/NewRelease/index.js
+++ b/src/shipit/frontend/src/views/NewRelease/index.js
@@ -126,7 +126,10 @@ export default class NewRelease extends React.Component {
     this.setState({
       revision: event.target.value,
     });
-    this.version = await getVersion(this.state.selectedBranch.repo, event.target.value);
+    this.version = await getVersion(
+      this.state.selectedBranch.repo, event.target.value,
+      this.state.selectedProduct.appName,
+    );
     await this.guessBuildId();
   };
 


### PR DESCRIPTION
I broke this when adding support for Thunderbird, as I only tested it with suggested revision.