### PR TITLE
staticanalysis/bot: Fix infer errors.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
@@ -25,10 +25,7 @@ ac_add_options --target=arm-linux-androideabi
 
 # With the following Android SDK and NDK:
 ac_add_options --with-android-sdk="{mozbuild}/android-sdk-linux/android-sdk-linux"
-ac_add_options --with-android-ndk="{mozbuild}/android-ndk/android-ndk"
-
-ac_add_options --with-java-bin-path="{openjdk}/bin"
-'''
+ac_add_options --with-android-ndk="{mozbuild}/android-ndk/android-ndk"'''
 
 
 def setup(index, job_name='linux64-infer', revision='latest',
@@ -88,9 +85,7 @@ class AndroidConfig():
         os.environ['MOZCONFIG'] = self.__android_mozconfig
         subprocess.run(['chmod', 'u+w', self.__android_mozconfig])
         with open(self.__android_mozconfig, 'a') as f:
-            f.write(ANDROID_MOZCONFIG.format(
-                mozbuild='/tmp/mozilla-state',
-                openjdk=os.getenv('JAVA_HOME')))
+            f.write(ANDROID_MOZCONFIG.format(mozbuild='/tmp/mozilla-state'))
 
     def __exit__(self, type, value, traceback):
         os.environ['MOZCONFIG'] = self.__old_config

--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -7,12 +7,17 @@ import itertools
 
 from static_analysis_bot.clang.format import ClangFormatIssue
 from static_analysis_bot.clang.tidy import ClangTidyIssue
+from static_analysis_bot.infer.infer import InferIssue
 from static_analysis_bot.lint import MozLintIssue
 
 COMMENT_PARTS = {
     ClangTidyIssue: {
         'defect': ' - {nb} found by clang-tidy',
         'analyzer': ' - `./mach static-analysis check path/to/file.cpp` (C/C++)',
+    },
+    InferIssue: {
+        'defect': ' - {nb} found by infer',
+        'analyzer': ' - `./mach static-analysis check-java path/to/file.java` (Java)',
     },
     ClangFormatIssue: {
         'defect': ' - {nb} found by clang-format',


### PR DESCRIPTION
This fixes the following errors:
* `./mach configure` failing when configuring the android build
* error regarding `InferIssues` not being supported