### PR TITLE
shipit/frontend: fix CSPs

### DIFF
--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -890,6 +890,7 @@ PROJECTS_CONFIG = {
                         'csp': [
                             'https://hg.mozilla.org',
                             'https://queue.taskcluster.net',
+                            'https://auth.mozilla.auth0.com',
                         ],
                     },
                     'staging': {
@@ -902,6 +903,7 @@ PROJECTS_CONFIG = {
                         'csp': [
                             'https://hg.mozilla.org',
                             'https://queue.taskcluster.net',
+                            'https://auth.mozilla.auth0.com',
                         ],
                     },
                     'production': {
@@ -914,6 +916,7 @@ PROJECTS_CONFIG = {
                         'csp': [
                             'https://hg.mozilla.org',
                             'https://queue.taskcluster.net',
+                            'https://auth.mozilla.auth0.com',
                         ],
                     },
                 },

--- a/src/shipit/frontend/default.nix
+++ b/src/shipit/frontend/default.nix
@@ -3,7 +3,7 @@
 
 releng_pkgs.lib.mkYarnFrontend {
   src = ./.;
-  csp = "default-src 'none'; img-src 'self' *.gravatar.com data:; script-src 'self' 'unsafe-inline'; style-src 'self'; font-src 'self'; frame-src 'self' https://auth.mozilla.auth0.com;";
+  csp = "default-src 'none'; img-src 'self' *.gravatar.com data:; script-src 'self' 'unsafe-inline' https://cdn.auth0.com; style-src 'self'; font-src 'self'; frame-src 'self' https://auth.mozilla.auth0.com;";
   src_path = "src/shipit/frontend";
   extraBuildInputs = with releng_pkgs.pkgs; [
     libpng


### PR DESCRIPTION
add auth0 domains to allow script-src and background re-auth