### PR TITLE
Infer - Download the artefacts from their appropriate places.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
@@ -36,15 +36,19 @@ def setup(index, job_name='linux64-infer', revision='latest',
     - Download the artifact from latest Taskcluster build
     - Extracts it into the MOZBUILD_STATE_PATH as expected by mach
     '''
-    NAMESPACE = 'gecko.cache.level-1.toolchains.v2.{}.{}'
     if job_name == 'linux64-infer':
-        job_names = ['linux64-infer', 'linux64-android-sdk-linux-repack',
-                     'linux64-android-ndk-linux-repack']
-        artifacts = ['public/build/infer.tar.xz',
-                     'project/gecko/android-sdk/android-sdk-linux.tar.xz',
-                     'project/gecko/android-ndk/android-ndk.tar.xz']
-        for job, artifact in zip(job_names, artifacts):
-            namespace = NAMESPACE.format(job, revision)
+        jobs = [
+            {'job-name': 'linux64-infer', 'artifact': 'public/build/infer.tar.xz',
+                'namespace': 'gecko.v2.autoland.latest.static-analysis.linux64-infer'},
+            {'job-name': 'linux64-android-sdk-linux-repack', 'artifact': 'project/gecko/android-sdk/android-sdk-linux.tar.xz',
+                'namespace': 'gecko.cache.level-1.toolchains.v2.linux64-android-sdk-linux-repack.latest'},
+            {'job-name': 'linux64-android-ndk-linux-repack', 'artifact': 'project/gecko/android-ndk/android-ndk.tar.xz',
+                'namespace': 'gecko.cache.level-1.toolchains.v2.linux64-android-ndk-linux-repack.latest'}
+        ]
+
+        for element in jobs:
+            namespace = element['namespace']
+            artifact = element['artifact']
             # on staging buildSignedUrl will fail, because the artifacts are downloaded from
             # a proxy, therefore we need to use buildUrl in case the signed version fails
             try:

--- a/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
@@ -38,12 +38,21 @@ def setup(index, job_name='linux64-infer', revision='latest',
     '''
     if job_name == 'linux64-infer':
         jobs = [
-            {'job-name': 'linux64-infer', 'artifact': 'public/build/infer.tar.xz',
-                'namespace': 'gecko.v2.autoland.latest.static-analysis.linux64-infer'},
-            {'job-name': 'linux64-android-sdk-linux-repack', 'artifact': 'project/gecko/android-sdk/android-sdk-linux.tar.xz',
-                'namespace': 'gecko.cache.level-1.toolchains.v2.linux64-android-sdk-linux-repack.latest'},
-            {'job-name': 'linux64-android-ndk-linux-repack', 'artifact': 'project/gecko/android-ndk/android-ndk.tar.xz',
-                'namespace': 'gecko.cache.level-1.toolchains.v2.linux64-android-ndk-linux-repack.latest'}
+            {
+                'job-name': 'linux64-infer',
+                'artifact': 'public/build/infer.tar.xz',
+                'namespace': 'gecko.v2.autoland.latest.static-analysis.linux64-infer'
+            },
+            {
+                'job-name': 'linux64-android-sdk-linux-repack',
+                'artifact': 'project/gecko/android-sdk/android-sdk-linux.tar.xz',
+                'namespace': 'gecko.cache.level-1.toolchains.v2.linux64-android-sdk-linux-repack.latest'
+            },
+            {
+                'job-name': 'linux64-android-ndk-linux-repack',
+                'artifact': 'project/gecko/android-ndk/android-ndk.tar.xz',
+                'namespace': 'gecko.cache.level-1.toolchains.v2.linux64-android-ndk-linux-repack.latest'
+            }
         ]
 
         for element in jobs:


### PR DESCRIPTION
linux64-infer is not in the same namespace with the android-*
artefacts, so we need to use distinct namespaces when dealing with the
link request.