### PR TITLE
staticanalysis/bot: Properly format markdown snippets in clang-tidy and clang-format comments.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/clang/format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/format.py
@@ -184,14 +184,14 @@ class ClangFormatIssue(Issue):
         '''
         out = 'Warning: Incorrect coding style [clang-format]\n'
         if self.mode == OPCODE_REPLACE:
-            out += 'Replace by: \n\n{}\n'.format(self.new)
+            out += 'Replace by:\n\n```\n{}\n```\n'.format(self.new)
 
         elif self.mode == OPCODE_INSERT:
-            out += 'Insert at this line: \n\n{}\n'.format(self.new)
+            out += 'Insert at this line:\n\n```\n{}\n```\n'.format(self.new)
 
         elif self.mode == OPCODE_DELETE:
             if self.nb_lines > 1:
-                out += 'Delete these {} lines'.format(self.nb_lines)
+                out += 'Delete these {} lines.'.format(self.nb_lines)
             out += 'Delete this line.'
 
         else:

--- a/src/staticanalysis/bot/static_analysis_bot/clang/tidy.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/tidy.py
@@ -307,7 +307,7 @@ class ClangTidyIssue(Issue):
 
         # Always add body as it's been cleaned up
         if self.body:
-            body += '\n{}'.format(self.body)
+            body += '\n```\n{}\n```'.format(self.body)
 
         return body
 

--- a/src/staticanalysis/bot/tests/mocks/clang-issues.txt
+++ b/src/staticanalysis/bot/tests/mocks/clang-issues.txt
@@ -1,66 +1,92 @@
 Warning: Do not use 'else' after 'return' [clang-tidy: readability-else-after-return]
+```
 
   else // readability-else-after-return
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 --------------------
 Error: Methods annotated with MOZ_NO_DANGLING_ON_TEMPORARIES cannot be && ref-qualified [clang-tidy: mozilla-dangling-on-temporary]
+```
 
   MOZ_NO_DANGLING_ON_TEMPORARIES int *get() && { return nullptr; } // mozilla-dangling-on-temporary
                                       ^
+```
 --------------------
 Error: Methods annotated with MOZ_NO_DANGLING_ON_TEMPORARIES must return a pointer [clang-tidy: mozilla-dangling-on-temporary]
+```
 
   MOZ_NO_DANGLING_ON_TEMPORARIES int test() { return 0; } // mozilla-dangling-on-temporary
                                      ^
+```
 --------------------
 Warning: Redundant void argument list in function definition [clang-tidy: modernize-redundant-void-arg]
+```
 
 JS::ObjectOpResult::failCantRedefineProp(void) // modernize-redundant-void-arg
                                          ^~~~~
+```
 --------------------
 Warning: Redundant void argument list in function definition [clang-tidy: modernize-redundant-void-arg]
+```
 
 JS_GetImplementationVersion(void)
                             ^~~~~
+```
 --------------------
 Warning: Escaped string literal can be written as a raw string literal [clang-tidy: modernize-raw-string-literal]
+```
 
                                "\"string\", \"number\", or \"default\"", source);
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                R"("string", "number", or "default")"
+```
 --------------------
 Warning: Use auto when initializing with a cast to avoid duplicating the type name [clang-tidy: modernize-use-auto]
+```
 
     uintptr_t u = reinterpret_cast<uintptr_t>(name);
     ^~~~~~~~~
     auto
+```
 --------------------
 Warning: Use '= default' to define a trivial default constructor [clang-tidy: modernize-use-equals-default]
+```
 
     AutoFile()
     ^
+```
 --------------------
 Warning: Use '= default' to define a trivial destructor [clang-tidy: modernize-use-equals-default]
+```
 
     ~AutoFile()
     ^
+```
 --------------------
 Warning: Use '= default' to define a trivial destructor [clang-tidy: modernize-use-equals-default]
+```
 
 JS::AutoSetAsyncStackForNewCalls::~AutoSetAsyncStackForNewCalls()
                                   ^
+```
 --------------------
 Warning: Use '= default' to define a trivial default constructor [clang-tidy: modernize-use-equals-default]
+```
 
 JSErrorNotes::JSErrorNotes()
               ^
+```
 --------------------
 Warning: Use '= default' to define a trivial destructor [clang-tidy: modernize-use-equals-default]
+```
 
 JSErrorNotes::~JSErrorNotes()
               ^
+```
 --------------------
 Warning: Redundant void argument list in function definition [clang-tidy: modernize-redundant-void-arg]
+```
 
 JS_PUBLIC_API(void)
               ^~~~~
+```

--- a/src/staticanalysis/bot/tests/test_clang.py
+++ b/src/staticanalysis/bot/tests/test_clang.py
@@ -243,7 +243,7 @@ def test_as_text(mock_revision):
     issue = ClangTidyIssue(parts, mock_revision)
     issue.body = 'Dummy body withUppercaseChars'
 
-    assert issue.as_text() == 'Error: Dummy message withUppercaseChars [clang-tidy: dummy-check]\nDummy body withUppercaseChars'
+    assert issue.as_text() == 'Error: Dummy message withUppercaseChars [clang-tidy: dummy-check]\n```\nDummy body withUppercaseChars\n```'
 
 
 def test_as_markdown(mock_revision):


### PR DESCRIPTION
Now that MozReview is gone, and that comments are no longer synced to Bugzilla, we can leverage markdown.

In fact, our comments are already treated as markdown by Phabricator, causing our snippets to occasionally look a bit strange, because part of the snippet is outside the code block:

https://phabricator-dev.allizom.org/D697#inline-17044