### PR TITLE
please_cli: Changed name parameter of 'click.group' to show correct output (#1071)

### DIFF
--- a/lib/please_cli/please_cli/__init__.py
+++ b/lib/please_cli/please_cli/__init__.py
@@ -66,8 +66,7 @@ Happy hacking!
 )
 
 
-@click.group("please", cls=please_cli.utils.ClickCustomGroup,
-             invoke_without_command=True, help=CMD_HELP, epilog=CMD_EPILOG)
+@click.group("please", cls=please_cli.utils.ClickCustomGroup, invoke_without_command=True, help=CMD_HELP, epilog=CMD_EPILOG)
 @click.option('-v', '--verbose', count=True, help='Increase verbosity level')
 @click.version_option(version=please_cli.config.VERSION)
 @click.help_option()

--- a/lib/please_cli/please_cli/utils.py
+++ b/lib/please_cli/please_cli/utils.py
@@ -81,6 +81,9 @@ class ClickCustomCommand(click.Command):
 class ClickCustomGroup(click.Group, ClickCustomCommand):
     """A custom click group Command which doesn't indent help and epilog text.
     """
+    def format_usage(self, ctx, formatter):
+        pieces = self.collect_usage_pieces(ctx)
+        formatter.write_usage('./please', ' '.join(pieces))
 
     def format_options(self, ctx, formatter):
         ClickCustomCommand.format_options(self, ctx, formatter)


### PR DESCRIPTION
Changed name param of 'click.group' so that `./please --help` does not show `.please-wrapper`.