### PR TITLE
staticanalysis/bot: Update prefilled issue format

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -10,7 +10,7 @@ from static_analysis_bot import stats
 from static_analysis_bot.report.base import Reporter
 from static_analysis_bot.revisions import PhabricatorRevision
 
-BUG_REPORT_URL = 'https://bit.ly/2tb8Qk3'
+BUG_REPORT_URL = 'https://bit.ly/2IyNRy2'
 
 logger = log.get_logger(__name__)
 


### PR DESCRIPTION
Stop mentioning 'shipit_static_analysis', add a 'app:staticanalysis/bot' label and add a 'SUMMARY' placeholder in the title so that developers give a meaningful title.