### PR TITLE
staticanalysis/bot: Slightly improve the clang-format patch URL message.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -41,9 +41,7 @@ If you see a problem in this automated review, please report it here: {bug_repor
 '''
 COMMENT_DIFF_DOWNLOAD = '''
 
-A full diff for the formatting issues found by clang-format is provided here: {url}
-
-You can use it in your repository with `hg import` or `git apply`
+For your convenience, here is a patch that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply`): {url}
 '''
 
 
@@ -139,10 +137,10 @@ class Reporter(object):
             defects='\n'.join(defects),
             analyzers='\n'.join(analyzers),
         )
-        comment += BUG_REPORT.format(bug_report_url=bug_report_url)
         if ClangFormatIssue in stats and diff_url is not None:
             comment += COMMENT_DIFF_DOWNLOAD.format(
                 url=diff_url,
             )
+        comment += BUG_REPORT.format(bug_report_url=bug_report_url)
 
         return comment

--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -34,13 +34,11 @@ Code analysis found {defects_total} in this patch{extras_comments}:
 
 You can run this analysis locally with:
 {analyzers}
-
 '''
 BUG_REPORT = '''
 If you see a problem in this automated review, please report it here: {bug_report_url}
 '''
 COMMENT_DIFF_DOWNLOAD = '''
-
 For your convenience, here is a patch that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply`): {url}
 '''
 

--- a/src/staticanalysis/bot/tests/conftest.py
+++ b/src/staticanalysis/bot/tests/conftest.py
@@ -160,8 +160,22 @@ def mock_phabricator():
 
     responses.add(
         responses.POST,
+        'http://phabricator.test/api/differential.createinline',
+        body=_response('createinline'),
+        content_type='application/json',
+    )
+
+    responses.add(
+        responses.POST,
         'http://phabricator.test/api/edge.search',
         body=_response('edge_search'),
+        content_type='application/json',
+    )
+
+    responses.add(
+        responses.POST,
+        'http://phabricator.test/api/transaction.search',
+        body=_response('transaction_search'),
         content_type='application/json',
     )
 

--- a/src/staticanalysis/bot/tests/mocks/phabricator_createinline.json
+++ b/src/staticanalysis/bot/tests/mocks/phabricator_createinline.json
@@ -1,0 +1,14 @@
+{
+    "result": {
+        "id": 17073,
+        "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+        "filePath": ".arcconfig",
+        "isNewFile": false,
+        "lineNumber": 2,
+        "lineLength": 0,
+        "diffID": "1158",
+        "content": "Such comment, wow"
+    },
+    "error_code": null,
+    "error_info": null
+}

--- a/src/staticanalysis/bot/tests/mocks/phabricator_transaction_search.json
+++ b/src/staticanalysis/bot/tests/mocks/phabricator_transaction_search.json
@@ -1,0 +1,278 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 26739,
+                "phid": "PHID-XACT-DREV-qemz3i72fv7brv6",
+                "type": null,
+                "authorPHID": "PHID-APPS-PhabricatorHarbormasterApplication",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1539001143,
+                "dateModified": 1539001143,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26738,
+                "phid": "PHID-XACT-DREV-sdpmqr6aowkb7f4",
+                "type": "update",
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1539001142,
+                "dateModified": 1539001142,
+                "comments": [],
+                "fields": {
+                    "old": "PHID-DIFF-3imcuyzrmmhdpgrr5w6r",
+                    "new": "PHID-DIFF-iu3aoh7r2r3dt6mifdyi",
+                    "commitPHIDs": []
+                }
+            },
+            {
+                "id": 26730,
+                "phid": "PHID-XACT-DREV-miwcmwculx2qtle",
+                "type": null,
+                "authorPHID": "PHID-APPS-PhabricatorHarbormasterApplication",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538751842,
+                "dateModified": 1538751842,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26728,
+                "phid": "PHID-XACT-DREV-gnq344u3wtuztrm",
+                "type": "update",
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538751840,
+                "dateModified": 1538751840,
+                "comments": [],
+                "fields": {
+                    "old": "PHID-DIFF-ffrmwh6qhekydjukpozu",
+                    "new": "PHID-DIFF-3imcuyzrmmhdpgrr5w6r",
+                    "commitPHIDs": []
+                }
+            },
+            {
+                "id": 26726,
+                "phid": "PHID-XACT-DREV-b5i5xltak6nasaj",
+                "type": null,
+                "authorPHID": "PHID-APPS-PhabricatorHarbormasterApplication",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538746113,
+                "dateModified": 1538746113,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26724,
+                "phid": "PHID-XACT-DREV-ny35kxbatcep7km",
+                "type": "update",
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538746111,
+                "dateModified": 1538746111,
+                "comments": [],
+                "fields": {
+                    "old": "PHID-DIFF-5tgaftrsvnjrezdov5an",
+                    "new": "PHID-DIFF-ffrmwh6qhekydjukpozu",
+                    "commitPHIDs": []
+                }
+            },
+            {
+                "id": 26713,
+                "phid": "PHID-XACT-DREV-4njbgrh6y6xiwox",
+                "type": null,
+                "authorPHID": "PHID-APPS-PhabricatorHarbormasterApplication",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538734415,
+                "dateModified": 1538734415,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26711,
+                "phid": "PHID-XACT-DREV-ye47rsxm6l2igf3",
+                "type": "update",
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538734413,
+                "dateModified": 1538734413,
+                "comments": [],
+                "fields": {
+                    "old": "PHID-DIFF-3reimpzvzlbnn7hhmjrc",
+                    "new": "PHID-DIFF-5tgaftrsvnjrezdov5an",
+                    "commitPHIDs": []
+                }
+            },
+            {
+                "id": 26709,
+                "phid": "PHID-XACT-DREV-qo3dr7nuurvf2by",
+                "type": "request-review",
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728580,
+                "dateModified": 1538728580,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26708,
+                "phid": "PHID-XACT-DREV-njkeayiil4kvtmg",
+                "type": null,
+                "authorPHID": "PHID-APPS-PhabricatorHarbormasterApplication",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728580,
+                "dateModified": 1538728580,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26707,
+                "phid": "PHID-XACT-DREV-vadfyd7bvrrxgis",
+                "type": null,
+                "authorPHID": "PHID-USER-4h42forhbb7uvkzui4vr",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728579,
+                "dateModified": 1538728579,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26706,
+                "phid": "PHID-XACT-DREV-23h4iez62wtj6bj",
+                "type": null,
+                "authorPHID": "PHID-USER-4h42forhbb7uvkzui4vr",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728579,
+                "dateModified": 1538728579,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26705,
+                "phid": "PHID-XACT-DREV-6qpgforb2fzpuui",
+                "type": null,
+                "authorPHID": "PHID-USER-4h42forhbb7uvkzui4vr",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728579,
+                "dateModified": 1538728579,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26699,
+                "phid": "PHID-XACT-DREV-q3qted3huli5h4f",
+                "type": null,
+                "authorPHID": "PHID-APPS-PhabricatorHeraldApplication",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728571,
+                "dateModified": 1538728571,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26697,
+                "phid": "PHID-XACT-DREV-pxker7tneerqxsa",
+                "type": null,
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728570,
+                "dateModified": 1538728570,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26696,
+                "phid": "PHID-XACT-DREV-cbrb7uk7id7wlbk",
+                "type": "update",
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728570,
+                "dateModified": 1538728570,
+                "comments": [],
+                "fields": {
+                    "old": null,
+                    "new": "PHID-DIFF-3reimpzvzlbnn7hhmjrc",
+                    "commitPHIDs": []
+                }
+            },
+            {
+                "id": 26695,
+                "phid": "PHID-XACT-DREV-dqjza5qczc5wrea",
+                "type": null,
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728570,
+                "dateModified": 1538728570,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26694,
+                "phid": "PHID-XACT-DREV-p7iybi3dzarljbw",
+                "type": null,
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728570,
+                "dateModified": 1538728570,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26693,
+                "phid": "PHID-XACT-DREV-xzfkgqjqdnq4bqg",
+                "type": "title",
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728570,
+                "dateModified": 1538728570,
+                "comments": [],
+                "fields": {
+                    "old": "",
+                    "new": "Bug 1387052 - Make Firefox code worse intentionally 2/2."
+                }
+            },
+            {
+                "id": 26692,
+                "phid": "PHID-XACT-DREV-wftxzaz7ezbejku",
+                "type": null,
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728570,
+                "dateModified": 1538728570,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26691,
+                "phid": "PHID-XACT-DREV-5qi7lgfoq6eckcp",
+                "type": null,
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728570,
+                "dateModified": 1538728570,
+                "comments": [],
+                "fields": {}
+            },
+            {
+                "id": 26690,
+                "phid": "PHID-XACT-DREV-h72u2lewetvvzgq",
+                "type": "create",
+                "authorPHID": "PHID-USER-qvozgl7osyqxo226fzye",
+                "objectPHID": "PHID-DREV-doduylefdefj4mtjw2le",
+                "dateCreated": 1538728570,
+                "dateModified": 1538728570,
+                "comments": [],
+                "fields": {}
+            }
+        ],
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -8,20 +8,31 @@ import urllib
 
 import responses
 
-VALID_MESSAGE = '''
+VALID_CLANG_TIDY_MESSAGE = '''
 Code analysis found 1 defect in this patch:
  - 1 defect found by clang-tidy
 
 You can run this analysis locally with:
  - `./mach static-analysis check path/to/file.cpp` (C/C++)
 
+If you see a problem in this automated review, please report it here: https://bit.ly/2IyNRy2
+'''
+
+VALID_CLANG_FORMAT_MESSAGE = '''
+Code analysis found 1 defect in this patch:
+ - 1 defect found by clang-format
+
+You can run this analysis locally with:
+ - `./mach clang-format -p path/to/file.cpp` (C/C++)
+
+For your convenience, here is a patch that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply`): https://diff.url
 
 If you see a problem in this automated review, please report it here: https://bit.ly/2IyNRy2
 '''
 
 
 @responses.activate
-def test_phabricator(mock_repository, mock_phabricator):
+def test_phabricator_clang_tidy(mock_repository, mock_phabricator):
     '''
     Test Phabricator reporter publication on a mock clang-tidy issue
     '''
@@ -37,7 +48,7 @@ def test_phabricator(mock_repository, mock_phabricator):
         details = json.loads(payload['params'][0])
         assert details == {
             'revision_id': 51,
-            'message': VALID_MESSAGE,
+            'message': VALID_CLANG_TIDY_MESSAGE,
             'attach_inlines': 1,
             '__conduit__': {'token': 'deadbeef'},
         }
@@ -66,5 +77,56 @@ def test_phabricator(mock_repository, mock_phabricator):
     issue_parts = ('test.cpp', '42', '51', 'error', 'dummy message', 'modernize-use-nullptr')
     issue = ClangTidyIssue(issue_parts, revision)
     assert issue.is_publishable()
+
+    reporter.publish([issue, ], revision)
+
+
+@responses.activate
+def test_phabricator_clang_format(mock_repository, mock_phabricator):
+    '''
+    Test Phabricator reporter publication on a mock clang-format issue
+    '''
+    from static_analysis_bot.report.phabricator import PhabricatorReporter
+    from static_analysis_bot.revisions import PhabricatorRevision
+    from static_analysis_bot.clang.format import ClangFormatIssue
+
+    def _check_comment(request):
+        # Check the Phabricator main comment is well formed
+        payload = urllib.parse.parse_qs(request.body)
+        assert payload['output'] == ['json']
+        assert len(payload['params']) == 1
+        details = json.loads(payload['params'][0])
+        assert details['message'] == VALID_CLANG_FORMAT_MESSAGE
+
+        # Outputs dummy empty response
+        resp = {
+            'error_code': None,
+            'result': None,
+        }
+        return 201, {'Content-Type': 'application/json'}, json.dumps(resp)
+
+    responses.add_callback(
+        responses.POST,
+        'http://phabricator.test/api/differential.createcomment',
+        callback=_check_comment,
+    )
+
+    with mock_phabricator as api:
+        revision = PhabricatorRevision('PHID-DIFF-abcdef', api)
+        revision.lines = {
+            # Add dummy lines diff
+            'test.cpp': [41, 42, 43],
+        }
+        reporter = PhabricatorReporter(api=api)
+
+    a = []
+    b = []
+    mode = 'insert'
+    line = 42
+    opcode = (mode, line, 0, 0, 0)
+    issue = ClangFormatIssue('test.cpp', a, b, opcode, revision)
+    assert issue.is_publishable()
+
+    revision.diff_url = 'https://diff.url'
 
     reporter.publish([issue, ], revision)

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -3,21 +3,51 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
+import urllib
+
 import responses
+
+VALID_MESSAGE = '''
+Code analysis found 1 defect in this patch:
+ - 1 defect found by clang-tidy
+
+You can run this analysis locally with:
+ - `./mach static-analysis check path/to/file.cpp` (C/C++)
+
+
+If you see a problem in this automated review, please report it here: https://bit.ly/2IyNRy2
+'''
 
 
 @responses.activate
-def test_phabricator(tmpdir, mock_phabricator):
+def test_phabricator(mock_repository, mock_phabricator):
     '''
-    Test Phabricator reporter
+    Test Phabricator reporter publication on a mock clang-tidy issue
     '''
     from static_analysis_bot.report.phabricator import PhabricatorReporter
     from static_analysis_bot.revisions import PhabricatorRevision
     from static_analysis_bot.clang.tidy import ClangTidyIssue
 
     def _check_comment(request):
-        assert request.body == 'FAIL'
-        # payload = json.loads(request.body)
+        # Check the Phabricator main comment is well formed
+        payload = urllib.parse.parse_qs(request.body)
+        assert payload['output'] == ['json']
+        assert len(payload['params']) == 1
+        details = json.loads(payload['params'][0])
+        assert details == {
+            'revision_id': 51,
+            'message': VALID_MESSAGE,
+            'attach_inlines': 1,
+            '__conduit__': {'token': 'deadbeef'},
+        }
+
+        # Outputs dummy empty response
+        resp = {
+            'error_code': None,
+            'result': None,
+        }
+        return 201, {'Content-Type': 'application/json'}, json.dumps(resp)
 
     responses.add_callback(
         responses.POST,
@@ -27,14 +57,14 @@ def test_phabricator(tmpdir, mock_phabricator):
 
     with mock_phabricator as api:
         revision = PhabricatorRevision('PHID-DIFF-abcdef', api)
-        reporter = PhabricatorReporter()
-        reporter.setup_api(api)
+        revision.lines = {
+            # Add dummy lines diff
+            'test.cpp': [41, 42, 43],
+        }
+        reporter = PhabricatorReporter(api=api)
 
-    issue_parts = ('test.cpp', '42', '51', 'error', 'dummy message', 'dummy-check')
-    issues = [
-      ClangTidyIssue(issue_parts, revision)
-    ]
+    issue_parts = ('test.cpp', '42', '51', 'error', 'dummy message', 'modernize-use-nullptr')
+    issue = ClangTidyIssue(issue_parts, revision)
+    assert issue.is_publishable()
 
-    reporter.publish(issues, revision)
-
-    # TODO: How to intercept the Phabricator review comment?
+    reporter.publish([issue, ], revision)

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import responses
+
+
+@responses.activate
+def test_phabricator(tmpdir, mock_phabricator):
+    '''
+    Test Phabricator reporter
+    '''
+    from static_analysis_bot.report.phabricator import PhabricatorReporter
+    from static_analysis_bot.revisions import PhabricatorRevision
+    from static_analysis_bot.clang.tidy import ClangTidyIssue
+
+    def _check_comment(request):
+        assert request.body == 'FAIL'
+        # payload = json.loads(request.body)
+
+    responses.add_callback(
+        responses.POST,
+        'http://phabricator.test/api/differential.createcomment',
+        callback=_check_comment,
+    )
+
+    with mock_phabricator as api:
+        revision = PhabricatorRevision('PHID-DIFF-abcdef', api)
+        reporter = PhabricatorReporter()
+        reporter.setup_api(api)
+
+    issue_parts = ('test.cpp', '42', '51', 'error', 'dummy message', 'dummy-check')
+    issues = [
+      ClangTidyIssue(issue_parts, revision)
+    ]
+
+    reporter.publish(issues, revision)
+
+    # TODO: How to intercept the Phabricator review comment?


### PR DESCRIPTION
Using the suggestion from #1271 (and also swapping the diff URL and the bug report URL).