### PR TITLE
Change the expiration for signedURL

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/infer/__init__.py
@@ -63,7 +63,8 @@ def setup(index, job_name='linux64-infer', revision='latest',
             try:
                 artifact_url = index.buildSignedUrl('findArtifactFromTask',
                                                     indexPath=namespace,
-                                                    name=artifact)
+                                                    name=artifact,
+                                                    expiration=7200)
             except taskcluster.exceptions.TaskclusterAuthFailure:
                 artifact_url = index.buildUrl('findArtifactFromTask',
                                               indexPath=namespace,


### PR DESCRIPTION
The current expiration for a signedURL is 15 minutes. Since we are downloading two large artifacts this might take longer, this leads to authentication failures.