### PR TITLE
staticanalysis/bot: Fix clang-tidy & clang-format paths

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/clang/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/__init__.py
@@ -11,14 +11,20 @@ import cli_common.utils
 from static_analysis_bot import AnalysisException
 
 
-def setup(product='static-analysis', job_name='linux64-clang-tidy', revision='latest', artifact='public/build/clang-tidy.tar.xz'):
+def setup(
+    product='static-analysis',
+    job_name='linux64-clang-tidy',
+    revision='latest',
+    artifact='public/build/clang-tidy.tar.xz',
+    repository='autoland',
+):
     '''
     Setup Taskcluster clang build for static-analysis
     Defaults values are from https://dxr.mozilla.org/mozilla-central/source/taskcluster/ci/toolchain/linux.yml
     - Download the artifact from latest Taskcluster build
     - Extracts it into the MOZBUILD_STATE_PATH as expected by mach
     '''
-    namespace = 'gecko.v2.autoland.{}.{}.{}'.format(revision, product, job_name)
+    namespace = 'gecko.v2.{}.{}.{}.{}'.format(repository, revision, product, job_name)
     artifact_url = 'https://index.taskcluster.net/v1/task/{}/artifacts/{}'.format(namespace, artifact)
 
     # Mach expects clang binaries in this specific root dir

--- a/src/staticanalysis/bot/static_analysis_bot/clang/format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/format.py
@@ -47,7 +47,7 @@ class ClangFormat(object):
     def __init__(self):
         self.binary = os.path.join(
             os.environ['MOZBUILD_STATE_PATH'],
-            'clang-tools', 'clang', 'bin', 'clang-format',
+            'clang-tools', 'clang-tidy', 'bin', 'clang-format',
         )
         assert os.path.exists(self.binary), \
             'Missing clang-format in {}'.format(self.binary)

--- a/src/staticanalysis/bot/static_analysis_bot/clang/tidy.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/tidy.py
@@ -69,7 +69,7 @@ class ClangTidy(object):
     def __init__(self, validate_checks=True):
         self.binary = os.path.join(
             os.environ['MOZBUILD_STATE_PATH'],
-            'clang-tools', 'clang', 'bin', 'clang-tidy',
+            'clang-tools', 'clang-tidy', 'bin', 'clang-tidy',
         )
         assert os.path.exists(self.binary), \
             'Missing clang-tidy in {}'.format(self.binary)

--- a/src/staticanalysis/bot/static_analysis_bot/workflow.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflow.py
@@ -177,8 +177,9 @@ class Workflow(object):
                     raise AnalysisException('mach', str(e))
 
                 # Download clang build from Taskcluster
+                # Use new clang-tidy paths, https://bugzilla.mozilla.org/show_bug.cgi?id=1495641
                 logger.info('Setup Taskcluster clang build...')
-                setup_clang()
+                setup_clang(repository='mozilla-inbound', revision='revision.874a07fdb045b725edc2aaa656a8620ff439ec10')
 
                 # Use clang-tidy & clang-format
                 if CLANG_TIDY in self.analyzers:

--- a/src/staticanalysis/bot/tests/conftest.py
+++ b/src/staticanalysis/bot/tests/conftest.py
@@ -241,7 +241,7 @@ def mock_clang(tmpdir, monkeypatch):
     '''
 
     # Create a temp mozbuild path
-    clang_dir = tmpdir.mkdir('clang-tools').mkdir('clang').mkdir('bin')
+    clang_dir = tmpdir.mkdir('clang-tools').mkdir('clang-tidy').mkdir('bin')
     os.environ['MOZBUILD_STATE_PATH'] = str(tmpdir.realpath())
 
     for tool in ('clang-tidy', 'clang-format'):


### PR DESCRIPTION
From https://bugzilla.mozilla.org/show_bug.cgi?id=1495641