### PR TITLE
cli_common: Lock taskcluster to 4.0.1

### DIFF
--- a/lib/cli_common/requirements-dev.txt
+++ b/lib/cli_common/requirements-dev.txt
@@ -28,4 +28,4 @@ python-dateutil<2.7.0,>=2.1
 python-hglib
 raven
 structlog
-taskcluster
+taskcluster==4.0.1


### PR DESCRIPTION
Fixes #1604.