### PR TITLE
releng_frontend: Add a note that win64 mingw clang doesn't run tests

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -84,7 +84,7 @@
                 <label><input type="checkbox" name="platform" value="win32-mingw32">win32 mingw32</label> <span class="info">(no tests)</span>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="win64-mingwclang">win64 mingw clang</label>
+                <label><input type="checkbox" name="platform" value="win64-mingwclang">win64 mingw clang</label> <span class="info">(no tests)</span>
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="win64">win64</label>


### PR DESCRIPTION
Small follow-up to #1599.