### PR TITLE
codecoverage/bot: Fix detection of Windows platforms

### DIFF
--- a/src/codecoverage/bot/code_coverage_bot/taskcluster.py
+++ b/src/codecoverage/bot/code_coverage_bot/taskcluster.py
@@ -129,7 +129,7 @@ def get_suite(chunk_name):
 def get_platform(name):
     if 'linux' in name:
         return 'linux'
-    elif 'windows' in name or 'win' in name:
+    elif 'win' in name:
         return 'windows'
     elif 'android-test' in name:
         return 'android-test'

--- a/src/codecoverage/bot/code_coverage_bot/taskcluster.py
+++ b/src/codecoverage/bot/code_coverage_bot/taskcluster.py
@@ -129,7 +129,7 @@ def get_suite(chunk_name):
 def get_platform(name):
     if 'linux' in name:
         return 'linux'
-    elif 'windows' in name:
+    elif 'windows' in name or 'win' in name:
         return 'windows'
     elif 'android-test' in name:
         return 'android-test'

--- a/src/codecoverage/bot/tests/test_taskcluster.py
+++ b/src/codecoverage/bot/tests/test_taskcluster.py
@@ -161,6 +161,10 @@ def test_get_platform():
     tests = [
         ('test-linux64-ccov/debug-mochitest-1', 'linux'),
         ('test-windows10-64-ccov/debug-mochitest-1', 'windows'),
+        ('build-linux64-ccov/debug', 'linux'),
+        ('build-win64-ccov/debug', 'windows'),
+        ('build-android-test-ccov/opt', 'android-test'),
+        ('test-android-em-4.3-arm7-api-16-ccov/debug-robocop-2', 'android-emulator'),
     ]
 
     for (name, platform) in tests:


### PR DESCRIPTION
`build-win64-ccov/debug` doesn't contain `windows`, so we have to adjust `get_platform`.