### PR TITLE
codecoverage/bot: Update ActiveData query URL

### DIFF
--- a/src/codecoverage/bot/code_coverage_bot/chunk_mapping.py
+++ b/src/codecoverage/bot/code_coverage_bot/chunk_mapping.py
@@ -14,8 +14,7 @@ from code_coverage_bot import taskcluster
 
 logger = get_logger(__name__)
 
-# TODO: Change the IP to a domain name when bug 1429482 is fixed.
-ACTIVEDATA_QUERY_URL = 'http://54.149.21.8/query'
+ACTIVEDATA_QUERY_URL = 'http://activedata.allizom.org/query'
 
 PLATFORMS = ['linux', 'windows']
 IGNORED_SUITE_PREFIXES = ['awsy', 'talos', 'test-coverage', 'test-coverage-wpt']


### PR DESCRIPTION
The best solution would be to use a secret here so it's configurable easily, but this is the smallest possible fix for the next release.