### PR TITLE
shipit/api: Use env vars for TC IRC notifications

### DIFF
--- a/src/shipit/api/shipit_api/__init__.py
+++ b/src/shipit/api/shipit_api/__init__.py
@@ -27,8 +27,8 @@ def create_app(config=None):
 
     app.notify = cli_common.taskcluster.get_service(
         'notify',
-        app.config.get('TASKCLUSTER_CLIENT_ID'),
-        app.config.get('TASKCLUSTER_ACCESS_TOKEN')
+        os.environ.get('TASKCLUSTER_CLIENT_ID'),
+        os.environ.get('TASKCLUSTER_ACCESS_TOKEN'),
     )
 
     app.api.register(os.path.join(os.path.dirname(__file__), 'api.yml'))

--- a/src/shipit/api/shipit_api/__init__.py
+++ b/src/shipit/api/shipit_api/__init__.py
@@ -27,8 +27,8 @@ def create_app(config=None):
 
     app.notify = cli_common.taskcluster.get_service(
         'notify',
-        os.environ.get('TASKCLUSTER_CLIENT_ID'),
-        os.environ.get('TASKCLUSTER_ACCESS_TOKEN'),
+        os.environ.get('TASKCLUSTER_CLIENT_ID', app.config.get('TASKCLUSTER_CLIENT_ID')),
+        os.environ.get('TASKCLUSTER_ACCESS_TOKEN', app.config.get('TASKCLUSTER_CLIENT_ID')),
     )
 
     app.api.register(os.path.join(os.path.dirname(__file__), 'api.yml'))


### PR DESCRIPTION
This should stop using the TC credentials from the secrets and fix the "Auth failures".