### PR TITLE
uplift/bot: Add a BUGZILLA_COMMENT_ONLY setting in order to report failed uplifts without cancelling requests.

### DIFF
--- a/src/uplift/bot/uplift_bot/cli.py
+++ b/src/uplift/bot/uplift_bot/cli.py
@@ -38,6 +38,7 @@ def main(bugzilla_id,
                               'BUGZILLA_URL',
                               'BUGZILLA_TOKEN',
                               'BUGZILLA_READ_ONLY',
+                              'BUGZILLA_COMMENT_ONLY',
                               'API_URL',
                               'APP_CHANNEL',
                               'UPLIFT_NOTIFICATIONS',
@@ -45,6 +46,7 @@ def main(bugzilla_id,
                           existing=dict(
                               APP_CHANNEL='development',
                               BUGZILLA_READ_ONLY=True,
+                              BUGZILLA_COMMENT_ONLY=False,
                               UPLIFT_NOTIFICATIONS=['babadie@mozilla.com'],
                           ),
                           taskcluster_client_id=taskcluster_client_id,
@@ -71,6 +73,7 @@ def main(bugzilla_id,
         secrets['BUGZILLA_URL'],
         secrets['BUGZILLA_TOKEN'],
         secrets['BUGZILLA_READ_ONLY'],
+        secrets['BUGZILLA_COMMENT_ONLY'],
     )
     bot.use_cache(cache_root)
     if bugzilla_id:

--- a/src/uplift/bot/uplift_bot/sync.py
+++ b/src/uplift/bot/uplift_bot/sync.py
@@ -170,7 +170,7 @@ class Bot(object):
         # Init report
         self.report = Report(notification_emails)
 
-    def use_bugzilla(self, bugzilla_url, bugzilla_token=None, read_only=True):
+    def use_bugzilla(self, bugzilla_url, bugzilla_token=None, read_only=True, comment_only=False):
         '''
         Setup bugzilla usage (url + token)
         '''
@@ -178,6 +178,7 @@ class Bot(object):
         self.repository = None
         self.bugzilla_url = bugzilla_url
         self.bugzilla_read_only = read_only
+        self.bugzilla_comment_only = comment_only
 
         use_bugzilla(bugzilla_url, bugzilla_token)
         logger.info('Use bugzilla server', url=self.bugzilla_url)
@@ -325,7 +326,7 @@ class Bot(object):
         # Save invalid merge in report, and cancel the uplift request
         if not merge_test.is_valid():
             self.report.add_invalid_merge(merge_test)
-            cancel_uplift_request(merge_test, self.bugzilla_read_only)
+            cancel_uplift_request(merge_test, self.bugzilla_read_only, self.bugzilla_comment_only)
 
     def delete_bug(self, sync):
         '''


### PR DESCRIPTION
Eventually, Uplift Bot should be able to cancel uplift requests that aren't valid.

However, until we're sufficiently confident that Uplift Bot can correctly identify invalid uplifts (without false positives), we should let it post a comment on Bugzilla, but without cancelling the `approval-mozilla-{beta,release,esr*}` flag, nor setting needinfos.

This will allow us to soft-launch Uplift Bot, and go through a trial phase where we evaluate / iterate on its results, before giving it full cancellation power.