### PR TITLE
codecoverage/bot: Use a placeholder chunk for build tasks to avoid having empty chunks

### DIFF
--- a/src/codecoverage/bot/code_coverage_bot/chunk_mapping.py
+++ b/src/codecoverage/bot/code_coverage_bot/chunk_mapping.py
@@ -172,6 +172,8 @@ def generate(repo_dir, revision, artifactsHandler, out_dir='.'):
                     if not is_chunk_only_suite(suite):
                         continue
 
+                    assert chunk.strip() != '', 'chunk can not be an empty string'
+
                     future = executor.submit(grcov.files_list, artifactsHandler.get(platform=platform, chunk=chunk), source_dir=repo_dir)
                     futures[future] = (platform, chunk)
 

--- a/src/codecoverage/bot/code_coverage_bot/taskcluster.py
+++ b/src/codecoverage/bot/code_coverage_bot/taskcluster.py
@@ -100,14 +100,18 @@ def download_artifact(artifact_path, task_id, artifact_name):
     retry(perform_download)
 
 
-TEST_PLATFORMS = [
+BUILD_PLATFORMS = [
     'build-linux64-ccov/debug',
-    'test-linux64-ccov/debug',
     'build-win64-ccov/debug',
-    'test-windows10-64-ccov/debug',
-    'test-android-em-4.3-arm7-api-16-ccov/debug',
     'build-android-test-ccov/opt',
 ]
+
+
+TEST_PLATFORMS = [
+    'test-linux64-ccov/debug',
+    'test-windows10-64-ccov/debug',
+    'test-android-em-4.3-arm7-api-16-ccov/debug',
+] + BUILD_PLATFORMS
 
 
 def is_coverage_task(task):
@@ -115,6 +119,10 @@ def is_coverage_task(task):
 
 
 def get_chunk(name):
+    # Some tests are run on build machines, we define a placeholder chunk for those.
+    if name in BUILD_PLATFORMS:
+        return 'build'
+
     for t in TEST_PLATFORMS:
         if name.startswith(t):
             name = name[len(t) + 1:]

--- a/src/codecoverage/bot/tests/test_taskcluster.py
+++ b/src/codecoverage/bot/tests/test_taskcluster.py
@@ -139,6 +139,9 @@ def test_get_chunk():
         ('test-windows10-64-ccov/debug-mochitest-1', 'mochitest-1'),
         ('test-windows10-64-ccov/debug-mochitest-e10s-7', 'mochitest-7'),
         ('test-windows10-64-ccov/debug-cppunit', 'cppunit'),
+        ('build-linux64-ccov/debug', 'build'),
+        ('build-android-test-ccov/opt', 'build'),
+        ('build-win64-ccov/debug', 'build'),
     ]
 
     for (name, chunk) in tests:
@@ -151,6 +154,7 @@ def test_get_suite():
         ('mochitest-7', 'mochitest'),
         ('cppunit', 'cppunit'),
         ('firefox-ui-functional-remote', 'firefox-ui-functional-remote'),
+        ('build', 'build'),
     ]
 
     for (chunk, suite) in tests:


### PR DESCRIPTION
Fixes #1681.