### PR TITLE
shipit/api: update release status

### DIFF
--- a/src/shipit/api/shipit_api/api.yml
+++ b/src/shipit/api/shipit_api/api.yml
@@ -106,7 +106,6 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Release'
-
   /releases/{name}:
     get:
       summary: Release info
@@ -134,6 +133,30 @@ paths:
       responses:
         200:
           description: Returns release representation
+          schema:
+            $ref: '#/definitions/Release'
+    patch:
+      summary: Update release status
+      operationId: shipit_api.api.update_release_status
+      consumes:
+      - "application/json"
+      parameters:
+      - name: name
+        in: path
+        required: true
+        type: string
+        description: release name
+      - in: body
+        name: body
+        description: Release status object
+        required: true
+        schema:
+          $ref: '#/definitions/ReleaseStatus'
+      responses:
+        405:
+          description: Invalid input
+        200:
+          description: Release updated
           schema:
             $ref: '#/definitions/Release'
 
@@ -214,6 +237,19 @@ definitions:
       partial_updates:
         type: object
         default: {}
+
+  ReleaseStatus:
+    type: object
+    required:
+      - status
+    properties:
+      status:
+        type: string
+        example: scheduled
+        enum:
+          - scheduled
+          - shipped
+          - aborted
 
   Phase:
     type: object


### PR DESCRIPTION
In the future we will need to update the release status explicitly from
a in-tree scheduled task, so we mark a release as completed only after
all required tasks are done (bouncer, tests, etc).