### PR TITLE
staticanalysis/bot: Filter clang-format publishable issues by their path 

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/clang/format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/format.py
@@ -134,9 +134,9 @@ class ClangFormatIssue(Issue):
 
     def validates(self):
         '''
-        No specific rule on clang-format issues
+        Should match one of the allowed paths rules
         '''
-        return True
+        return settings.is_allowed_path(self.path)
 
     def as_text(self):
         '''

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -53,12 +53,14 @@ def main(source,
                               'REPORTERS',
                               'ANALYZERS',
                               'PHABRICATOR',
+                              'ALLOWED_PATHS',
                           ),
                           existing={
                               'APP_CHANNEL': 'development',
                               'REPORTERS': [],
                               'ANALYZERS': ['clang-tidy', ],
                               'PUBLICATION': 'IN_PATCH',
+                              'ALLOWED_PATHS': ['*', ],
                           },
                           taskcluster_client_id=taskcluster_client_id,
                           taskcluster_access_token=taskcluster_access_token,
@@ -72,7 +74,12 @@ def main(source,
                 )
 
     # Setup settings before stats
-    settings.setup(secrets['APP_CHANNEL'], cache_root, secrets['PUBLICATION'])
+    settings.setup(
+        secrets['APP_CHANNEL'],
+        cache_root,
+        secrets['PUBLICATION'],
+        secrets['ALLOWED_PATHS'],
+    )
 
     # Setup statistics
     datadog_api_key = secrets.get('DATADOG_API_KEY')

--- a/src/staticanalysis/bot/tests/conftest.py
+++ b/src/staticanalysis/bot/tests/conftest.py
@@ -45,7 +45,7 @@ def mock_config():
 
     from static_analysis_bot.config import settings
     tempdir = tempfile.mkdtemp()
-    settings.setup('test', tempdir, 'IN_PATCH')
+    settings.setup('test', tempdir, 'IN_PATCH', ['dom/*', 'tests/*.py'])
 
     return settings
 
@@ -278,7 +278,7 @@ def mock_clang(mock_config, tmpdir, monkeypatch):
             # Mock ./mach clang-format behaviour by analysing repo bad file
             # with the embedded clang-format from Nix
             # and replace this file with the output
-            target = os.path.join(mock_config.repo_dir, 'bad.cpp')
+            target = os.path.join(mock_config.repo_dir, 'dom', 'bad.cpp')
             out = real_run(['clang-format', target], *args, **kwargs)
             with open(target, 'w') as f:
                 f.write(out.stdout.decode('utf-8'))

--- a/src/staticanalysis/bot/tests/test_clang.py
+++ b/src/staticanalysis/bot/tests/test_clang.py
@@ -79,7 +79,8 @@ def test_clang_format(mock_config, mock_repository, mock_stats, mock_clang, mock
     from static_analysis_bot.config import settings
 
     # Write badly formatted c file
-    bad_file = os.path.join(mock_config.repo_dir, 'bad.cpp')
+    bad_file = os.path.join(mock_config.repo_dir, 'dom', 'bad.cpp')
+    os.makedirs(os.path.dirname(bad_file))
     with open(bad_file, 'w') as f:
         f.write(BAD_CPP_SRC)
 
@@ -89,9 +90,9 @@ def test_clang_format(mock_config, mock_repository, mock_stats, mock_clang, mock
 
     # Get formatting issues
     cf = ClangFormat()
-    mock_revision.files = ['bad.cpp', ]
+    mock_revision.files = ['dom/bad.cpp', ]
     mock_revision.lines = {
-        'bad.cpp': [1, 2, 3],
+        'dom/bad.cpp': [1, 2, 3],
     }
     issues = cf.run(mock_revision)
 
@@ -102,7 +103,7 @@ def test_clang_format(mock_config, mock_repository, mock_stats, mock_clang, mock
     assert isinstance(issue, ClangFormatIssue)
     assert issue.is_publishable()
 
-    assert issue.path == 'bad.cpp'
+    assert issue.path == 'dom/bad.cpp'
     assert issue.line == 2
     assert issue.nb_lines == 2
 

--- a/src/staticanalysis/bot/tests/test_issues.py
+++ b/src/staticanalysis/bot/tests/test_issues.py
@@ -165,3 +165,29 @@ def test_lines_hash(mock_config, test_cpp):
 
     for line in range(1, 5):
         assert_hash(TestIssue(line=line, path='another.h'), 'another line\n', 'b1401bec')
+
+
+def test_allowed_paths(mock_config):
+    '''
+    Test allowed paths for ClangFormatIssue
+    The test config has these 2 rules: dom/* and tests/*.py
+    '''
+    from static_analysis_bot.clang.format import ClangFormatIssue
+
+    def _allowed(path):
+        # Build an issue and check its validation
+        # that will trigger the path validation
+        issue = ClangFormatIssue(path, 1, 1, None)
+        return issue.validates()
+
+    checks = {
+        'nope.cpp': False,
+        'dom/whatever.cpp': True,
+        'dom/sub/folders/whatever.cpp': True,
+        'dom/noext': True,
+        'dom_fail.h': False,
+        'tests/xxx.pyc': False,
+        'tests/folder/part/1.py': True,
+    }
+    for path, result in checks.items():
+        assert _allowed(path) is result

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -127,10 +127,11 @@ def test_phabricator_clang_format(mock_repository, mock_phabricator):
         revision.lines = {
             # Add dummy lines diff
             'test.cpp': [41, 42, 43],
+            'dom/test.cpp': [42, ],
         }
         reporter = PhabricatorReporter({'analyzers': ['clang-format']}, api=api)
 
-    issue = ClangFormatIssue('test.cpp', 42, 1, revision)
+    issue = ClangFormatIssue('dom/test.cpp', 42, 1, revision)
     assert issue.is_publishable()
 
     revision.improvement_patches = {
@@ -169,11 +170,12 @@ def test_phabricator_analyzers(mock_config, mock_repository, mock_phabricator):
         revision = PhabricatorRevision('PHID-DIFF-abcdef', api)
         revision.lines = {
             'test.cpp': [41, 42, 43],
+            'dom/test.cpp': [42, ],
         }
         reporter = PhabricatorReporter({'analyzers': analyzers}, api=api)
 
         issues = [
-            ClangFormatIssue('test.cpp', 42, 1, revision),
+            ClangFormatIssue('dom/test.cpp', 42, 1, revision),
             ClangTidyIssue(('test.cpp', '42', '51', 'error', 'dummy message', 'modernize-use-nullptr'), revision),
             InferIssue({
                 'file': 'test.cpp',


### PR DESCRIPTION
Needed to activate clang-format code review on `dom/media/*`