### PR TITLE
please-cli: fix misleading error output

### DIFF
--- a/lib/please_cli/please_cli/run.py
+++ b/lib/please_cli/please_cli/run.py
@@ -99,6 +99,16 @@ def cmd(ctx, project, quiet, nix_shell,
                 ]),
                 nix_shell=nix_shell,
                 )
+
+        if result != 0 and 'psql: could not connect to server' in output:
+            click.secho('ERROR', fg='red')
+            raise click.UsageError(
+                'Could not connect to the database.\n\n'
+                'Please run:\n\n'
+                '    ./please run postgresql\n\n'
+                'in a separate terminal.'
+            )
+
         please_cli.utils.check_result(result, output)
 
         database_exists = False

--- a/lib/please_cli/please_cli/run.py
+++ b/lib/please_cli/please_cli/run.py
@@ -99,6 +99,7 @@ def cmd(ctx, project, quiet, nix_shell,
                 ]),
                 nix_shell=nix_shell,
                 )
+        please_cli.utils.check_result(result, output)
 
         database_exists = False
         for line in output.split('\n'):
@@ -106,17 +107,6 @@ def cmd(ctx, project, quiet, nix_shell,
             if column1 == dbname:
                 database_exists = True
                 break
-
-        if result != 0:
-            click.secho('ERROR', fg='red')
-            raise click.UsageError(
-                'Could not connect to the database.\n\n'
-                'Please run:\n\n'
-                '    ./please run postgresql\n\n'
-                'in a separate terminal.'
-            )
-
-        please_cli.utils.check_result(result, output)
 
         if not database_exists:
             click.echo(' => Creating `{}` database ` ... '.format(dbname), nl=False)


### PR DESCRIPTION
#914 

this PR show all of the error output, instead of giving suggestion
```
'Please run:\n\n'	
'    ./please run postgresql\n\n'	
'in a separate terminal.
```

the error is because to run postgres, it run `psql` command using nix-shell, and nix-shell have checkPhase which includes pylint and flake8 before running the actual command. These checkPhase are able to throw error, however in the code, whatever error thrown, it will only show one suggestion. I changed it to show the output instead, so we can deduce what error is causing it to fail from the output

