### PR TITLE
codecoverage/bot: add generate zero coverage report on some platform but not on another

### DIFF
--- a/src/codecoverage/bot/code_coverage_bot/codecov.py
+++ b/src/codecoverage/bot/code_coverage_bot/codecov.py
@@ -153,6 +153,17 @@ class CodeCov(object):
             zc = ZeroCov(self.repo_dir)
             zc.generate(self.artifactsHandler.get(), self.revision, self.github_revision)
 
+            logger.info('Generating zero coverage on some platform but not on another reports')
+            report = {
+                'linux': zc.generate(
+                    self.artifactsHandler.get(platform='linux'),
+                    self.revision, self.github_revision, return_result=True),
+                'windows': zc.generate(
+                    self.artifactsHandler.get(platform='windows'),
+                    self.revision, self.github_revision, return_result=True)
+            }
+            zc.generate_zero_coverage_some_platform_only(report, self.revision, self.github_revision)
+
             logger.info('Generating chunk mapping')
             chunk_mapping.generate(self.repo_dir, self.revision, self.artifactsHandler)
 

--- a/src/codecoverage/bot/code_coverage_bot/codecov.py
+++ b/src/codecoverage/bot/code_coverage_bot/codecov.py
@@ -157,10 +157,10 @@ class CodeCov(object):
             reports = {
                 'linux': zc.generate(
                     self.artifactsHandler.get(platform='linux'),
-                    self.revision, self.github_revision, return_result=True),
+                    self.revision, self.github_revision, writeout_result=False),
                 'windows': zc.generate(
                     self.artifactsHandler.get(platform='windows'),
-                    self.revision, self.github_revision, return_result=True)
+                    self.revision, self.github_revision, writeout_result=False)
             }
             zc.generate_zero_coverage_some_platform_only(reports, self.revision, self.github_revision)
 

--- a/src/codecoverage/bot/code_coverage_bot/codecov.py
+++ b/src/codecoverage/bot/code_coverage_bot/codecov.py
@@ -154,15 +154,11 @@ class CodeCov(object):
             zc.generate(self.artifactsHandler.get(), self.revision, self.github_revision)
 
             logger.info('Generating zero coverage on some platform but not on another reports')
-            reports = {
-                'linux': zc.generate(
-                    self.artifactsHandler.get(platform='linux'),
-                    self.revision, self.github_revision, writeout_result=False),
-                'windows': zc.generate(
-                    self.artifactsHandler.get(platform='windows'),
-                    self.revision, self.github_revision, writeout_result=False)
+            platforms_artifacts = {
+                'linux': self.artifactsHandler.get(platform='linux'),
+                'windows': self.artifactsHandler.get(platform='windows'),
             }
-            zc.generate_zero_coverage_some_platform_only(reports, self.revision, self.github_revision)
+            zc.generate_zero_coverage_some_platform_only(platforms_artifacts, self.revision, self.github_revision)
 
             logger.info('Generating chunk mapping')
             chunk_mapping.generate(self.repo_dir, self.revision, self.artifactsHandler)

--- a/src/codecoverage/bot/code_coverage_bot/codecov.py
+++ b/src/codecoverage/bot/code_coverage_bot/codecov.py
@@ -154,7 +154,7 @@ class CodeCov(object):
             zc.generate(self.artifactsHandler.get(), self.revision, self.github_revision)
 
             logger.info('Generating zero coverage on some platform but not on another reports')
-            report = {
+            reports = {
                 'linux': zc.generate(
                     self.artifactsHandler.get(platform='linux'),
                     self.revision, self.github_revision, return_result=True),
@@ -162,7 +162,7 @@ class CodeCov(object):
                     self.artifactsHandler.get(platform='windows'),
                     self.revision, self.github_revision, return_result=True)
             }
-            zc.generate_zero_coverage_some_platform_only(report, self.revision, self.github_revision)
+            zc.generate_zero_coverage_some_platform_only(reports, self.revision, self.github_revision)
 
             logger.info('Generating chunk mapping')
             chunk_mapping.generate(self.repo_dir, self.revision, self.artifactsHandler)

--- a/src/codecoverage/bot/code_coverage_bot/zero_coverage.py
+++ b/src/codecoverage/bot/code_coverage_bot/zero_coverage.py
@@ -109,18 +109,22 @@ class ZeroCov(object):
 
         for platform in platforms:
             for file_info in reports[platform]['files']:
-                uncovered_map[file_info['name']].add(platform)
-
                 all_files[file_info['name']] = file_info
                 platform_files[platform].add(file_info['name'])
 
+                if file_info['uncovered'] is True:
+                    uncovered_map[file_info['name']].add(platform)
+
         zero_coverage_info = []
         for fname, info in all_files.items():
-            platform_file_exist = {x for x in platforms if fname in platform_files[x]}
+            # skip covered files
+            if not uncovered_map[fname]:
+                continue
 
+            # skip file that is uncovered on all platform where file exist
+            platform_file_exist = {x for x in platforms if fname in platform_files[x]}
             covered = list(platform_file_exist - uncovered_map[fname])
-            if len(covered) == 0:
-                # skip file that is uncovered on all platform where file exist
+            if not covered:
                 continue
 
             uncovered = list(uncovered_map[fname])
@@ -128,6 +132,7 @@ class ZeroCov(object):
                 'covered_platforms': covered,
                 'uncovered_platforms': uncovered,
             })
+            del info['uncovered']
             zero_coverage_info.append(info)
 
         zero_coverage_report = {

--- a/src/codecoverage/bot/tests/conftest.py
+++ b/src/codecoverage/bot/tests/conftest.py
@@ -135,8 +135,26 @@ def jsvm_artifact():
 
 
 @pytest.fixture(scope='session')
-def jsvm_uncovered_linux_artifact():
-    with generate_coverage_artifact('jsvm_uncovered_file_linux.info') as f:
+def file1_covered_artifact():
+    with generate_coverage_artifact('file1_covered.info') as f:
+        yield f
+
+
+@pytest.fixture(scope='session')
+def file1_uncovered_artifact():
+    with generate_coverage_artifact('file1_uncovered.info') as f:
+        yield f
+
+
+@pytest.fixture(scope='session')
+def file2_covered_artifact():
+    with generate_coverage_artifact('file2_covered.info') as f:
+        yield f
+
+
+@pytest.fixture(scope='session')
+def file2_uncovered_artifact():
+    with generate_coverage_artifact('file2_uncovered.info') as f:
         yield f
 
 
@@ -234,6 +252,10 @@ def fake_hg_repo_with_contents(fake_hg_repo):
          'size': 5},
         {'name': 'code_coverage_bot/cli.py',
          'size': 6},
+        {'name': 'file1.jsm',
+         'size': 7},
+        {'name': 'file2.jsm',
+         'size': 8},
     ]
 
     for c in '?!':

--- a/src/codecoverage/bot/tests/conftest.py
+++ b/src/codecoverage/bot/tests/conftest.py
@@ -135,6 +135,12 @@ def jsvm_artifact():
 
 
 @pytest.fixture(scope='session')
+def jsvm_uncovered_linux_artifact():
+    with generate_coverage_artifact('jsvm_uncovered_file_linux.info') as f:
+        yield f
+
+
+@pytest.fixture(scope='session')
 def grcov_existing_file_artifact():
     with generate_coverage_artifact('grcov_existing_file.info') as f:
         yield f

--- a/src/codecoverage/bot/tests/fixtures/file1_covered.info
+++ b/src/codecoverage/bot/tests/fixtures/file1_covered.info
@@ -1,0 +1,12 @@
+SF:file1.jsm
+FN:1,top-level
+FN:2,open
+FNDA:1,top-level
+FNDA:1,open
+FNF:2
+FNH:2
+DA:1,42
+DA:2,42
+LF:2
+LH:2
+end_of_record

--- a/src/codecoverage/bot/tests/fixtures/file1_uncovered.info
+++ b/src/codecoverage/bot/tests/fixtures/file1_uncovered.info
@@ -1,0 +1,12 @@
+SF:file1.jsm
+FN:1,top-level
+FN:2,open
+FNDA:1,top-level
+FNDA:0,open
+FNF:2
+FNH:1
+DA:1,42
+DA:2,0
+LF:2
+LH:1
+end_of_record

--- a/src/codecoverage/bot/tests/fixtures/file2_covered.info
+++ b/src/codecoverage/bot/tests/fixtures/file2_covered.info
@@ -1,0 +1,12 @@
+SF:file2.jsm
+FN:1,top-level
+FN:2,open
+FNDA:1,top-level
+FNDA:1,open
+FNF:2
+FNH:2
+DA:1,42
+DA:2,42
+LF:2
+LH:2
+end_of_record

--- a/src/codecoverage/bot/tests/fixtures/file2_uncovered.info
+++ b/src/codecoverage/bot/tests/fixtures/file2_uncovered.info
@@ -1,4 +1,4 @@
-SF:toolkit/components/osfile/osfile.jsm
+SF:file2.jsm
 FN:1,top-level
 FN:2,open
 FNDA:1,top-level

--- a/src/codecoverage/bot/tests/fixtures/jsvm_uncovered_file_linux.info
+++ b/src/codecoverage/bot/tests/fixtures/jsvm_uncovered_file_linux.info
@@ -1,0 +1,12 @@
+SF:toolkit/components/osfile/osfile.jsm
+FN:1,top-level
+FN:2,open
+FNDA:1,top-level
+FNDA:0,open
+FNF:2
+FNH:1
+DA:1,42
+DA:2,0
+LF:2
+LH:1
+end_of_record

--- a/src/codecoverage/bot/tests/test_zero_coverage.py
+++ b/src/codecoverage/bot/tests/test_zero_coverage.py
@@ -52,11 +52,11 @@ def test_zero_coverage_some_platform(tmpdir,
         {'funcs': 1, 'name': 'mozglue/build/dummy.cpp', 'uncovered': True,
          'size': 1, 'commits': 2,
          'first_push_date': today, 'last_push_date': today,
-         'covered_platform': ['linux'], 'uncovered_platform': ['windows']},
+         'covered_platforms': ['linux'], 'uncovered_platforms': ['windows']},
         {'funcs': 1, 'name': 'toolkit/components/osfile/osfile-win.jsm', 'uncovered': True,
          'size': 4, 'commits': 2,
          'first_push_date': today, 'last_push_date': today,
-         'covered_platform': ['windows'], 'uncovered_platform': ['linux']},
+         'covered_platforms': ['windows'], 'uncovered_platforms': ['linux']},
     ]
     assert len(zero_coverage_functions) == len(expected_zero_coverage_functions)
     while len(expected_zero_coverage_functions):
@@ -73,8 +73,8 @@ def test_zero_coverage_some_platform(tmpdir,
         assert found_item['size'] == exp_item['size']
         assert found_item['commits'] == exp_item['commits']
         assert found_item['uncovered'] == exp_item['uncovered']
-        assert found_item['covered_platform'] == exp_item['covered_platform']
-        assert found_item['uncovered_platform'] == exp_item['uncovered_platform']
+        assert found_item['covered_platforms'] == exp_item['covered_platforms']
+        assert found_item['uncovered_platforms'] == exp_item['uncovered_platforms']
 
 
 def test_zero_coverage(tmpdir,

--- a/src/codecoverage/bot/tests/test_zero_coverage.py
+++ b/src/codecoverage/bot/tests/test_zero_coverage.py
@@ -8,6 +8,75 @@ import pytz
 from code_coverage_bot.zero_coverage import ZeroCov
 
 
+def test_zero_coverage_some_platform(tmpdir,
+                                     grcov_artifact, grcov_uncovered_artifact,
+                                     jsvm_artifact, jsvm_uncovered_artifact,
+                                     grcov_uncovered_function_artifact, jsvm_uncovered_function_artifact,
+                                     fake_hg_repo_with_contents):
+    tmp_path = tmpdir.strpath
+
+    hgrev = '314159265358'
+    gitrev = '271828182845'
+
+    report = {
+        'linux': ZeroCov(fake_hg_repo_with_contents).generate([
+                jsvm_artifact, jsvm_uncovered_artifact,
+                jsvm_uncovered_function_artifact
+            ], hgrev, gitrev, out_dir=tmp_path, return_result=True),
+        'windows': ZeroCov(fake_hg_repo_with_contents).generate([
+                grcov_artifact, grcov_uncovered_artifact,
+                grcov_uncovered_function_artifact
+            ], hgrev, gitrev, out_dir=tmp_path, return_result=True)
+    }
+
+    ZeroCov(fake_hg_repo_with_contents).generate_zero_coverage_some_platform_only(
+        report,
+        hgrev,
+        gitrev,
+        out_dir=tmp_path
+    )
+
+    with open(os.path.join(tmp_path, 'zero_coverage_some_platform_functions_report.json'), 'r') as f:
+        zero_coverage_report = json.load(f)
+
+    assert 'hg_revision' in zero_coverage_report and zero_coverage_report['hg_revision'] == hgrev
+    assert 'github_revision' in zero_coverage_report and zero_coverage_report['github_revision'] == gitrev
+    assert 'files' in zero_coverage_report
+    zero_coverage_functions = zero_coverage_report['files']
+
+    today = datetime.utcnow()
+    today = pytz.utc.localize(today)
+    today = today.strftime(ZeroCov.DATE_FORMAT)
+
+    expected_zero_coverage_functions = [
+        {'funcs': 1, 'name': 'mozglue/build/dummy.cpp', 'uncovered': True,
+         'size': 1, 'commits': 2,
+         'first_push_date': today, 'last_push_date': today,
+         'covered_platform': ['linux'], 'uncovered_platform': ['windows']},
+        {'funcs': 1, 'name': 'toolkit/components/osfile/osfile-win.jsm', 'uncovered': True,
+         'size': 4, 'commits': 2,
+         'first_push_date': today, 'last_push_date': today,
+         'covered_platform': ['windows'], 'uncovered_platform': ['linux']},
+    ]
+    assert len(zero_coverage_functions) == len(expected_zero_coverage_functions)
+    while len(expected_zero_coverage_functions):
+        exp_item = expected_zero_coverage_functions.pop()
+        found = False
+        for found_item in zero_coverage_functions:
+            if found_item['name'] == exp_item['name']:
+                found = True
+                break
+        assert found
+        assert found_item['funcs'] == exp_item['funcs']
+        assert found_item['first_push_date'] == exp_item['first_push_date']
+        assert found_item['last_push_date'] == exp_item['last_push_date']
+        assert found_item['size'] == exp_item['size']
+        assert found_item['commits'] == exp_item['commits']
+        assert found_item['uncovered'] == exp_item['uncovered']
+        assert found_item['covered_platform'] == exp_item['covered_platform']
+        assert found_item['uncovered_platform'] == exp_item['uncovered_platform']
+
+
 def test_zero_coverage(tmpdir,
                        grcov_artifact, grcov_uncovered_artifact,
                        jsvm_artifact, jsvm_uncovered_artifact,

--- a/src/codecoverage/bot/tests/test_zero_coverage.py
+++ b/src/codecoverage/bot/tests/test_zero_coverage.py
@@ -9,30 +9,33 @@ from code_coverage_bot.zero_coverage import ZeroCov
 
 
 def test_zero_coverage_some_platform(tmpdir,
-                                     grcov_artifact, grcov_uncovered_artifact,
-                                     jsvm_artifact, jsvm_uncovered_artifact,
-                                     jsvm_uncovered_linux_artifact,
-                                     grcov_uncovered_function_artifact, jsvm_uncovered_function_artifact,
+                                     file1_covered_artifact,
+                                     file1_uncovered_artifact,
+                                     file2_covered_artifact,
+                                     file2_uncovered_artifact,
+                                     grcov_uncovered_artifact,
+                                     jsvm_uncovered_artifact,
                                      fake_hg_repo_with_contents):
     tmp_path = tmpdir.strpath
 
     hgrev = '314159265358'
     gitrev = '271828182845'
 
-    report = {
-        'linux': ZeroCov(fake_hg_repo_with_contents).generate([
-                jsvm_artifact, jsvm_uncovered_artifact,
-                jsvm_uncovered_function_artifact
-            ], hgrev, gitrev, out_dir=tmp_path, writeout_result=True),
-        'windows': ZeroCov(fake_hg_repo_with_contents).generate([
-                jsvm_uncovered_linux_artifact,
-                grcov_artifact, grcov_uncovered_artifact,
-                grcov_uncovered_function_artifact
-            ], hgrev, gitrev, out_dir=tmp_path, writeout_result=True)
+    platform_artifacts = {
+        'linux': [
+                jsvm_uncovered_artifact,
+                file1_covered_artifact,
+                file2_uncovered_artifact,
+            ],
+        'windows': [
+                grcov_uncovered_artifact,
+                file1_uncovered_artifact,
+                file2_covered_artifact,
+            ]
     }
 
     ZeroCov(fake_hg_repo_with_contents).generate_zero_coverage_some_platform_only(
-        report,
+        platform_artifacts,
         hgrev,
         gitrev,
         out_dir=tmp_path
@@ -53,16 +56,27 @@ def test_zero_coverage_some_platform(tmpdir,
     # result shouldnt include jsvm and grcov because they are not covered on all platform where the file exist
     expected_zero_coverage_functions = [
         {
-            'size': 2,
+            'name': 'file1.jsm',
+            'size': 7,
             'first_push_date': '2018-11-30',
             'last_push_date': '2018-11-30',
             'commits': 2,
-            'name': 'toolkit/components/osfile/osfile.jsm',
             'funcs': 1,
             'covered_platforms': ['linux'],
             'uncovered_platforms': ['windows']
-        }
+        },
+        {
+            'name': 'file2.jsm',
+            'size': 8,
+            'first_push_date': '2018-11-30',
+            'last_push_date': '2018-11-30',
+            'commits': 2,
+            'funcs': 1,
+            'covered_platforms': ['windows'],
+            'uncovered_platforms': ['linux']
+        },
     ]
+
     assert len(zero_coverage_functions) == len(expected_zero_coverage_functions)
     while len(expected_zero_coverage_functions):
         exp_item = expected_zero_coverage_functions.pop()


### PR DESCRIPTION
#1247 

This PR add a new function generate_zero_coverage_some_platform_only to generate a report where a function is uncovered on some platform, but not on another. currently it only supports linux and windows, however, it can be easily updated for other platforms