### PR TITLE
shipit/frontend: handle RC properly

### DIFF
--- a/src/shipit/frontend/src/configs/production.js
+++ b/src/shipit/frontend/src/configs/production.js
@@ -27,6 +27,8 @@ module.exports = {
           repo: 'https://hg.mozilla.org/releases/mozilla-release',
           enableReleaseEta: true,
           rcBranch: 'releases/mozilla-beta',
+          rcBranchVersionPattern: /b/,
+          rcRepo: 'https://hg.mozilla.org/releases/mozilla-beta',
         },
         {
           prettyName: 'ESR60',

--- a/src/shipit/frontend/src/views/NewRelease/index.js
+++ b/src/shipit/frontend/src/views/NewRelease/index.js
@@ -189,7 +189,7 @@ export default class NewRelease extends React.Component {
     this.setState({ inProgress: true });
     const { product } = this.state.selectedProduct;
     const {
-        branch, repo, rcBranch, rcBranchVersionPattern, rcRepo,
+      branch, repo, rcBranch, rcBranchVersionPattern, rcRepo,
     } = this.state.selectedBranch;
     const releaseObj = {
       product,


### PR DESCRIPTION
In case of RC releases we may have versions from different branches. In order to
fetch the l10n changesets, we need to detect the branch by matching the version
to a particular pattern and use a different repo in that case.