### PR TITLE
staticanalysis/bot: Better clang-format patch publication

### DIFF
--- a/lib/cli_common/cli_common/taskcluster.py
+++ b/lib/cli_common/cli_common/taskcluster.py
@@ -18,7 +18,7 @@ from cli_common.log import get_logger
 logger = get_logger(__name__)
 
 TASKCLUSTER_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
-
+TASKCLUSTER_ARTIFACT_URL = 'https://queue.taskcluster.net/v1/task/{task_id}/runs/{run_id}/artifacts/{path}'
 
 with open(taskcluster._client_importer.__file__) as f:
     TASKCLUSTER_SERVICES = [
@@ -224,4 +224,5 @@ def create_blob_artifact(queue_service, task_id, run_id, path, content, content_
     push.raise_for_status()
 
     # Build the absolute url
-    return f'https://queue.taskcluster.net/v1/task/{task_id}/runs/{run_id}/artifacts/{path}'
+    # TODO: use f-string once all project are on python 3.6
+    return TASKCLUSTER_ARTIFACT_URL.format(task_id=task_id, run_id=run_id, path=path)

--- a/lib/cli_common/cli_common/taskcluster.py
+++ b/lib/cli_common/cli_common/taskcluster.py
@@ -18,7 +18,6 @@ from cli_common.log import get_logger
 logger = get_logger(__name__)
 
 TASKCLUSTER_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
-TASKCLUSTER_ARTIFACT_URL = 'https://queue.taskcluster.net/v1/task/{task_id}/runs/{run_id}/artifacts/{path}'
 
 with open(taskcluster._client_importer.__file__) as f:
     TASKCLUSTER_SERVICES = [
@@ -224,5 +223,4 @@ def create_blob_artifact(queue_service, task_id, run_id, path, content, content_
     push.raise_for_status()
 
     # Build the absolute url
-    # TODO: use f-string once all project are on python 3.6
-    return TASKCLUSTER_ARTIFACT_URL.format(task_id=task_id, run_id=run_id, path=path)
+    return f'https://queue.taskcluster.net/v1/task/{task_id}/runs/{run_id}/artifacts/{path}'

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -100,6 +100,20 @@ def main(source,
         taskcluster_access_token,
     )
 
+    # Load queue service
+    queue_service = get_service(
+        'queue',
+        taskcluster_client_id,
+        taskcluster_access_token,
+    )
+
+    # TRASHME
+    from static_analysis_bot.revisions import ImprovementPatch
+    p = ImprovementPatch('test', 'mypatch', 'Hello World.')
+    p.publish(queue_service)
+
+    return
+
     # Load Phabricator API
     phabricator_api = PhabricatorAPI(**secrets['PHABRICATOR'])
     if 'phabricator' in reporters:
@@ -111,7 +125,7 @@ def main(source,
     else:
         raise Exception('Unsupported analysis source: {}'.format(source))
 
-    w = Workflow(reporters, secrets['ANALYZERS'], index_service, phabricator_api)
+    w = Workflow(reporters, secrets['ANALYZERS'], index_service, queue_service, phabricator_api)
     try:
         w.run(revision)
     except Exception as e:

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -107,13 +107,6 @@ def main(source,
         taskcluster_access_token,
     )
 
-    # TRASHME
-    from static_analysis_bot.revisions import ImprovementPatch
-    p = ImprovementPatch('test', 'mypatch', 'Hello World.')
-    p.publish(queue_service)
-
-    return
-
     # Load Phabricator API
     phabricator_api = PhabricatorAPI(**secrets['PHABRICATOR'])
     if 'phabricator' in reporters:

--- a/src/staticanalysis/bot/static_analysis_bot/config.py
+++ b/src/staticanalysis/bot/static_analysis_bot/config.py
@@ -20,6 +20,7 @@ PROJECT_NAME = 'static-analysis-bot'
 CONFIG_URL = 'https://hg.mozilla.org/mozilla-central/raw-file/tip/tools/clang-tidy/config.yaml'
 REPO_CENTRAL = b'https://hg.mozilla.org/mozilla-central'
 REPO_UNIFIED = b'https://hg.mozilla.org/mozilla-unified'
+TASKCLUSTER_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 
 logger = get_logger(__name__)

--- a/src/staticanalysis/bot/static_analysis_bot/config.py
+++ b/src/staticanalysis/bot/static_analysis_bot/config.py
@@ -20,7 +20,6 @@ PROJECT_NAME = 'static-analysis-bot'
 CONFIG_URL = 'https://hg.mozilla.org/mozilla-central/raw-file/tip/tools/clang-tidy/config.yaml'
 REPO_CENTRAL = b'https://hg.mozilla.org/mozilla-central'
 REPO_UNIFIED = b'https://hg.mozilla.org/mozilla-unified'
-TASKCLUSTER_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 
 logger = get_logger(__name__)
@@ -142,18 +141,6 @@ class Settings(object):
                 return c
 
         return None
-
-    def build_artifact_url(self, path):
-        '''
-        Build an url for a file in the results dir
-        '''
-        assert path.startswith(self.taskcluster.results_dir), \
-            'Path is not the artifact results dir'
-        return 'https://queue.taskcluster.net/v1/task/{}/runs/{}/artifacts/public/results/{}'.format(
-            self.taskcluster.task_id,
-            self.taskcluster.run_id,
-            path[len(self.taskcluster.results_dir)+1:],
-        )
 
 
 # Shared instance

--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -100,7 +100,7 @@ class Reporter(object):
             for cls, items in groups
         ])
 
-    def build_comment(self, issues, bug_report_url, patches={}, max_comments=None):
+    def build_comment(self, issues, bug_report_url, patches=[], max_comments=None):
         '''
         Build a Markdown comment about published issues
         '''
@@ -136,10 +136,10 @@ class Reporter(object):
             defects='\n'.join(defects),
             analyzers='\n'.join(analyzers),
         )
-        for analyzer, url in patches.items():
+        for patch in patches:
             comment += COMMENT_DIFF_DOWNLOAD.format(
-                analyzer=analyzer,
-                url=url,
+                analyzer=patch.analyzer,
+                url=patch.url or patch.path,
             )
         comment += BUG_REPORT.format(bug_report_url=bug_report_url)
 

--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -33,13 +33,14 @@ Code analysis found {defects_total} in this patch{extras_comments}:
 {defects}
 
 You can run this analysis locally with:
+
 {analyzers}
 '''
 BUG_REPORT = '''
 If you see a problem in this automated review, please report it here: {bug_report_url}
 '''
 COMMENT_DIFF_DOWNLOAD = '''
-For your convenience, here is a patch that fixes all the {analyzer} defects: {url} (use it in your repository with `hg import` or `git apply`)
+For your convenience, [here is a patch]({url}) that fixes all the {analyzer} defects (use it in your repository with `hg import` or `git apply`)
 '''
 
 
@@ -101,7 +102,7 @@ class Reporter(object):
 
     def build_comment(self, issues, bug_report_url, patches={}, max_comments=None):
         '''
-        Build a human readable comment about published issues
+        Build a Markdown comment about published issues
         '''
         def pluralize(word, nb):
             assert isinstance(word, str)

--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -33,7 +33,6 @@ Code analysis found {defects_total} in this patch{extras_comments}:
 {defects}
 
 You can run this analysis locally with:
-
 {analyzers}
 '''
 BUG_REPORT = '''

--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -36,7 +36,7 @@ You can run this analysis locally with:
 {analyzers}
 '''
 BUG_REPORT = '''
-If you see a problem in this automated review, please report it here: {bug_report_url}
+If you see a problem in this automated review, [please report it here]({bug_report_url}).
 '''
 COMMENT_DIFF_DOWNLOAD = '''
 For your convenience, [here is a patch]({url}) that fixes all the {analyzer} defects (use it in your repository with `hg import` or `git apply`)

--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -39,7 +39,7 @@ BUG_REPORT = '''
 If you see a problem in this automated review, [please report it here]({bug_report_url}).
 '''
 COMMENT_DIFF_DOWNLOAD = '''
-For your convenience, [here is a patch]({url}) that fixes all the {analyzer} defects (use it in your repository with `hg import` or `git apply`)
+For your convenience, [here is a patch]({url}) that fixes all the {analyzer} defects (use it in your repository with `hg import` or `git apply`).
 '''
 
 

--- a/src/staticanalysis/bot/static_analysis_bot/report/debug.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/debug.py
@@ -37,7 +37,7 @@ class DebugReporter(Reporter):
                 issue=str(issue),
             )
         for patch in revision.improvement_patches:
-            logger.info('Patch from {} as {}'.format(patch.analyzer, patch.url))
+            logger.info('Patch {}'.format(patch))
 
         # Output json report in public directory
         report = {
@@ -48,8 +48,8 @@ class DebugReporter(Reporter):
                 for issue in issues
             ],
             'patches': {
-                analyzer: url
-                for analyzer, url in revision.improvement_patches.items()
+                patch.analyzer: patch.url or patch.path
+                for patch in revision.improvement_patches
             },
         }
         with open(self.report_path, 'w') as f:

--- a/src/staticanalysis/bot/static_analysis_bot/report/debug.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/debug.py
@@ -36,8 +36,8 @@ class DebugReporter(Reporter):
                 'Issue {}'.format('publishable' if issue.is_publishable() else 'silent'),
                 issue=str(issue),
             )
-        for analyzer, url in revision.improvement_patches.items():
-            logger.info('Patch from {} as {}'.format(analyzer, url))
+        for patch in revision.improvement_patches:
+            logger.info('Patch from {} as {}'.format(patch.analyzer, patch.url))
 
         # Output json report in public directory
         report = {

--- a/src/staticanalysis/bot/static_analysis_bot/report/mail.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/mail.py
@@ -21,7 +21,7 @@ EMAIL_HEADER = '''
 Review Url: {review_url}
 
 '''
-EMAIL_HEADER_PATCH = '* Improvement patch from {} : {}'
+EMAIL_HEADER_PATCH = '* Improvement patch from {}'
 
 
 class MailReporter(Reporter):
@@ -66,7 +66,7 @@ class MailReporter(Reporter):
         if revision.improvement_patches:
             content += '## Improvement patches:\n\n{}\n\n'.format(
                 '\n'.join(
-                    EMAIL_HEADER_PATCH.format(patch.analyzer, patch.url)
+                    EMAIL_HEADER_PATCH.format(patch)
                     for patch in revision.improvement_patches
                 )
             )

--- a/src/staticanalysis/bot/static_analysis_bot/report/mail.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/mail.py
@@ -66,8 +66,8 @@ class MailReporter(Reporter):
         if revision.improvement_patches:
             content += '## Improvement patches:\n\n{}\n\n'.format(
                 '\n'.join(
-                    EMAIL_HEADER_PATCH.format(analyzer, url)
-                    for analyzer, url in revision.improvement_patches.items()
+                    EMAIL_HEADER_PATCH.format(patch.analyzer, patch.url)
+                    for patch in revision.improvement_patches
                 )
             )
         content += '\n\n'.join([i.as_markdown() for i in issues])

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -48,11 +48,7 @@ class PhabricatorReporter(Reporter):
         # and avoid publishing a non related patch from an anlyzer partly activated (allowed paths)
         issues = list(filter(lambda i: i.is_publishable() and i.ANALYZER in self.analyzers, issues))
         analyzers_available = set(i.ANALYZER for i in issues).intersection(self.analyzers)
-        patches = {
-            patch.analyzer: patch.url
-            for patch in revision.improvement_patches
-            if patch.analyzer in analyzers_available
-        }
+        patches = list(filter(lambda p: p.analyzer in analyzers_available, revision.improvement_patches))
 
         if issues:
 

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -5,6 +5,7 @@
 
 from cli_common import log
 from cli_common.phabricator import PhabricatorAPI
+from static_analysis_bot import CLANG_FORMAT
 from static_analysis_bot import Issue
 from static_analysis_bot import stats
 from static_analysis_bot.report.base import Reporter
@@ -56,8 +57,9 @@ class PhabricatorReporter(Reporter):
             inlines = list(filter(None, [
                 self.comment_inline(revision, issue, existing_comments)
                 for issue in issues
+                if issue.ANALYZER != CLANG_FORMAT
             ]))
-            if not inlines:
+            if not inlines and not patches:
                 logger.info('No new comments found, skipping Phabricator publication')
                 return
             logger.info('Added inline comments', ids=[i['id'] for i in inlines])

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -49,9 +49,9 @@ class PhabricatorReporter(Reporter):
         issues = list(filter(lambda i: i.is_publishable() and i.ANALYZER in self.analyzers, issues))
         analyzers_available = set(i.ANALYZER for i in issues).intersection(self.analyzers)
         patches = {
-            analyzer: url
-            for analyzer, url in revision.improvement_patches.items()
-            if analyzer in analyzers_available
+            patch.analyzer: patch.url
+            for patch in revision.improvement_patches
+            if patch.analyzer in analyzers_available
         }
 
         if issues:

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -11,7 +11,7 @@ from static_analysis_bot import stats
 from static_analysis_bot.report.base import Reporter
 from static_analysis_bot.revisions import PhabricatorRevision
 
-BUG_REPORT_URL = 'https://bit.ly/2IyNRy2'
+BUG_REPORT_URL = 'https://github.com/mozilla/release-services/issues/new?title=Problem%20with%20an%20automated%20review:%20SUMMARY&labels=app:staticanalysis/bot&body=**Phabricator%20URL:**%20https://phabricator.services.mozilla.com/D%E2%80%A6%0A%0A**Problem:**%20%E2%80%A6'  # noqa
 
 logger = log.get_logger(__name__)
 

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -47,9 +47,17 @@ class PhabricatorReporter(Reporter):
 
         # Use only publishable issues and patches
         # and avoid publishing a non related patch from an anlyzer partly activated (allowed paths)
-        issues = list(filter(lambda i: i.is_publishable() and i.ANALYZER in self.analyzers, issues))
+        issues = [
+            issue
+            for issue in issues
+            if issue.is_publishable() and issue.ANALYZER in self.analyzers
+        ]
         analyzers_available = set(i.ANALYZER for i in issues).intersection(self.analyzers)
-        patches = list(filter(lambda p: p.analyzer in analyzers_available, revision.improvement_patches))
+        patches = [
+            patch
+            for patch in revision.improvement_patches
+            if patch.analyzer in analyzers_available
+        ]
 
         if issues:
 

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -83,23 +83,26 @@ class ImprovementPatch(object):
         )
         pprint(payload)
         resp = queue_service.createArtifact(*payload)
+        assert resp['storageType'] == 'blob', 'Not a blob storage'
+        assert len(resp['requests']) == 1, 'Should only get one request'
+        request = resp['requests'][0]
+        assert request['method'] == 'PUT', 'Should get a PUT request'
 
         pprint(resp)
 
         # Push the artifact on storage service
         push = requests.put(
-            url=resp['putUrl'],
-            headers={
-                'Content-Type': resp['contentType'],
-            },
+            url=request['url'],
+            headers=request['headers'],
             data=self.content,
         )
         print(push)
         push.raise_for_status()
         print(push.content)
+        print(push.headers)
 
         # Build diff download url
-        self.url = settings.build_artifact_url(self.path)
+        # self.url = settings.build_artifact_url(self.path)
 
 
 class Revision(object):

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -46,11 +46,15 @@ class ImprovementPatch(object):
         # Build name from analyzer and revision
         self.analyzer = analyzer_name
         self.name = '{}-{}.diff'.format(analyzer_name, patch_name)
-        self.path = os.path.join(settings.taskcluster.results_dir, self.name)
         self.content = content
         self.url = None
+        self.path = None
+
+    def __str__(self):
+        return '{}: {}'.format(self.analyzer, self.url or self.path or self.name)
 
     def write(self):
+        self.path = os.path.join(settings.taskcluster.results_dir, self.name)
         with open(self.path, 'w') as f:
             length = f.write(self.content)
             logger.info('Improvement patch saved', path=self.path, length=length)

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -71,7 +71,7 @@ class ImprovementPatch(object):
             path='public/patch/{}'.format(self.name),
             content=self.content,
             content_type='text/plain; charset=utf-8',  # Displays instead of download):
-            ttl=timedelta(days=days_ttl - 1, hours=23),
+            ttl=timedelta(days=days_ttl - 1),
         )
         logger.info('Improvement patch published', url=self.url)
 

--- a/src/staticanalysis/bot/static_analysis_bot/workflow.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflow.py
@@ -14,6 +14,7 @@ import hglib
 from cli_common.command import run_check
 from cli_common.log import get_logger
 from cli_common.phabricator import PhabricatorAPI
+from cli_common.taskcluster import TASKCLUSTER_DATE_FORMAT
 from static_analysis_bot import CLANG_FORMAT
 from static_analysis_bot import CLANG_TIDY
 from static_analysis_bot import INFER
@@ -24,7 +25,6 @@ from static_analysis_bot.clang import setup as setup_clang
 from static_analysis_bot.clang.format import ClangFormat
 from static_analysis_bot.clang.tidy import ClangTidy
 from static_analysis_bot.config import REPO_UNIFIED
-from static_analysis_bot.config import TASKCLUSTER_DATE_FORMAT
 from static_analysis_bot.config import Publication
 from static_analysis_bot.config import settings
 from static_analysis_bot.infer import setup as setup_infer

--- a/src/staticanalysis/bot/static_analysis_bot/workflow.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflow.py
@@ -24,6 +24,7 @@ from static_analysis_bot.clang import setup as setup_clang
 from static_analysis_bot.clang.format import ClangFormat
 from static_analysis_bot.clang.tidy import ClangTidy
 from static_analysis_bot.config import REPO_UNIFIED
+from static_analysis_bot.config import TASKCLUSTER_DATE_FORMAT
 from static_analysis_bot.config import Publication
 from static_analysis_bot.config import settings
 from static_analysis_bot.infer import setup as setup_infer
@@ -42,7 +43,7 @@ class Workflow(object):
     '''
     Static analysis workflow
     '''
-    def __init__(self, reporters, analyzers, index_service, phabricator_api):
+    def __init__(self, reporters, analyzers, index_service, queue_service, phabricator_api):
         assert isinstance(analyzers, list)
         assert len(analyzers) > 0, \
             'No analyzers specified, will not run.'
@@ -62,8 +63,9 @@ class Workflow(object):
         # Always add debug reporter and Diff reporter
         self.reporters['debug'] = DebugReporter(output_dir=settings.taskcluster.results_dir)
 
-        # Use TC index service client
+        # Use TC services client
         self.index_service = index_service
+        self.queue_service = queue_service
 
     @stats.api.timed('runtime.clone')
     def clone(self):
@@ -237,6 +239,14 @@ class Workflow(object):
             self.index(revision, state='done', issues=0)
             return
 
+        # Publish patches on Taskcluster
+        # or write locally for local development
+        for patch in revision.improvement_patches:
+            if settings.taskcluster.local:
+                patch.write()
+            else:
+                patch.publish(self.queue_service)
+
         # Report issues publication stats
         nb_issues = len(issues)
         nb_publishable = len([i for i in issues if i.is_publishable()])
@@ -281,8 +291,7 @@ class Workflow(object):
 
         # Always add the indexing
         now = datetime.utcnow()
-        date_format = '%Y-%m-%dT%H:%M:%S.%fZ'
-        payload['indexed'] = now.strftime(date_format)
+        payload['indexed'] = now.strftime(TASKCLUSTER_DATE_FORMAT)
 
         # Index for all required namespaces
         for name in revision.namespaces:
@@ -293,6 +302,6 @@ class Workflow(object):
                     'taskId': settings.taskcluster.task_id,
                     'rank': 0,
                     'data': payload,
-                    'expires': (now + timedelta(days=TASKCLUSTER_INDEX_TTL)).strftime(date_format),
+                    'expires': (now + timedelta(days=TASKCLUSTER_INDEX_TTL)).strftime(TASKCLUSTER_DATE_FORMAT),
                 }
             )

--- a/src/staticanalysis/bot/tests/conftest.py
+++ b/src/staticanalysis/bot/tests/conftest.py
@@ -313,6 +313,7 @@ def mock_workflow(tmpdir, mock_repository, mock_config, mock_phabricator):
             reporters={},
             analyzers=['clang-tidy', 'clang-format', 'mozlint'],
             index_service=None,
+            queue_service=None,
             phabricator_api=api,
         )
     workflow.hg = workflow.clone()

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -16,7 +16,6 @@ Code analysis found 1 defect in this patch:
  - 1 defect found by clang-tidy
 
 You can run this analysis locally with:
-
  - `./mach static-analysis check path/to/file.cpp` (C/C++)
 
 If you see a problem in this automated review, please report it here: https://bit.ly/2IyNRy2
@@ -27,7 +26,6 @@ Code analysis found 1 defect in this patch:
  - 1 defect found by clang-format
 
 You can run this analysis locally with:
-
  - `./mach clang-format -p path/to/file.cpp` (C/C++)
 
 For your convenience, [here is a patch]({results}/clang-format-PHID-DIFF-abcdef.diff) that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply`)

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -28,7 +28,7 @@ Code analysis found 1 defect in this patch:
 You can run this analysis locally with:
  - `./mach clang-format -p path/to/file.cpp` (C/C++)
 
-For your convenience, [here is a patch]({results}/clang-format-PHID-DIFF-abcdef.diff) that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply`)
+For your convenience, [here is a patch]({results}/clang-format-PHID-DIFF-abcdef.diff) that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply`).
 
 If you see a problem in this automated review, [please report it here](https://github.com/mozilla/release-services/issues/new?title=Problem%20with%20an%20automated%20review:%20SUMMARY&labels=app:staticanalysis/bot&body=**Phabricator%20URL:**%20https://phabricator.services.mozilla.com/D%E2%80%A6%0A%0A**Problem:**%20%E2%80%A6).
 '''  # noqa

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -18,8 +18,8 @@ Code analysis found 1 defect in this patch:
 You can run this analysis locally with:
  - `./mach static-analysis check path/to/file.cpp` (C/C++)
 
-If you see a problem in this automated review, please report it here: https://bit.ly/2IyNRy2
-'''
+If you see a problem in this automated review, [please report it here](https://github.com/mozilla/release-services/issues/new?title=Problem%20with%20an%20automated%20review:%20SUMMARY&labels=app:staticanalysis/bot&body=**Phabricator%20URL:**%20https://phabricator.services.mozilla.com/D%E2%80%A6%0A%0A**Problem:**%20%E2%80%A6).
+'''  # noqa
 
 VALID_CLANG_FORMAT_MESSAGE = '''
 Code analysis found 1 defect in this patch:
@@ -30,7 +30,7 @@ You can run this analysis locally with:
 
 For your convenience, [here is a patch]({results}/clang-format-PHID-DIFF-abcdef.diff) that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply`)
 
-If you see a problem in this automated review, please report it here: https://bit.ly/2IyNRy2
+If you see a problem in this automated review, [please report it here](https://github.com/mozilla/release-services/issues/new?title=Problem%20with%20an%20automated%20review:%20SUMMARY&labels=app:staticanalysis/bot&body=**Phabricator%20URL:**%20https://phabricator.services.mozilla.com/D%E2%80%A6%0A%0A**Problem:**%20%E2%80%A6).
 '''  # noqa
 
 

--- a/src/staticanalysis/bot/tests/test_workflow.py
+++ b/src/staticanalysis/bot/tests/test_workflow.py
@@ -5,8 +5,6 @@
 
 from unittest import mock
 
-import pytest
-
 
 def test_taskcluster_index(mock_workflow, mock_config, mock_revision):
     '''
@@ -27,24 +25,3 @@ def test_taskcluster_index(mock_workflow, mock_config, mock_revision):
     assert args[1]['data']['id'] == '1234'
     assert args[1]['data']['source'] == 'mock'
     assert 'indexed' in args[1]['data']
-
-
-def test_taskcluster_artifacts(tmpdir, mock_config, mock_revision):
-    '''
-    Test the Taskcluster artifact url building
-    '''
-
-    from static_analysis_bot.config import TaskCluster
-    results = tmpdir.mkdir('results')
-    mock_config.taskcluster = TaskCluster(str(results), '12345deadbeef', 0, False)
-
-    # Write an artifact
-    artifact = results.join('something.txt')
-    artifact.write('dummy')
-
-    # Build url from absolute path
-    assert mock_config.build_artifact_url(str(artifact)) == 'https://queue.taskcluster.net/v1/task/12345deadbeef/runs/0/artifacts/public/results/something.txt'
-
-    # A path not in results dir should raise an exception
-    with pytest.raises(AssertionError):
-        mock_config.build_artifact_url('/tmp/nowhere.txt')


### PR DESCRIPTION
The goal is to display nicely the patch in browser (see #1696 ) :

- use `text/plain` content type through manual TC publication
- display link with Markdown formatting on phabricator
- remove clang-format inline comments