### PR TITLE
Nightly 66: Merge and deply when 66 builds are available for all locales

### DIFF
--- a/src/shipit/api/shipit_api/config.py
+++ b/src/shipit/api/shipit_api/config.py
@@ -38,7 +38,7 @@ ESR_BRANCH_PREFIX = 'releases/mozilla-esr'
 # day).
 # We could have used the in-tree version, but there can be race conditions,
 # e.g. version bumped, but still no builds available.
-FIREFOX_NIGHTLY = '65.0a1'
+FIREFOX_NIGHTLY = '66.0a1'
 # Aurora has been replaced by Dev Edition, but some 3rd party applications may
 # still rely on this value.
 FIREFOX_AURORA = ''


### PR DESCRIPTION
Making this commit as instructed in https://github.com/mozilla-releng/ship-it/blob/47b9c089a117b0066b50c4624af57f6e4970c564/kickoff/config.py#L1 for our upcoming release