### PR TITLE
Shellcheck safety checks

### DIFF
--- a/nix/docker/profile.sh
+++ b/nix/docker/profile.sh
@@ -3,7 +3,8 @@
 # Heavily cribbed from the equivalent NixOS login script.
 # This should work better with multi-user nix setups.
 
-export USER=`whoami`
+USER=$(whoami)
+export USER
 export NIXPKGS_CONFIG="/etc/nix/nixpkgs-config.nix"
 export NIX_OTHER_STORES="/run/nix/remote-stores/\*/nix"
 export NIX_USER_PROFILE_DIR="/nix/var/nix/profiles/per-user/$USER"
@@ -13,7 +14,7 @@ fi
 export PATH="$HOME/.nix-profile/bin:$HOME/.nix-profile/sbin:/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:$PATH"
 
 # Use the nix daemon for multi-user builds
-if [ "$USER" != root -o ! -w /nix/var/nix/db ]; then
+if [ "$USER" != root ] || [ ! -w /nix/var/nix/db ]; then
   export NIX_REMOTE=daemon
 fi
 
@@ -42,7 +43,7 @@ if [ -w "$HOME" ]; then
   fi
 
   # Set up a default Nix expression from which to install stuff.
-  if [ ! -e "$HOME/.nix-defexpr" -o -L "$HOME/.nix-defexpr" ]; then
+  if [ ! -e "$HOME/.nix-defexpr" ] || [ -L "$HOME/.nix-defexpr" ]; then
     rm -f "$HOME/.nix-defexpr"
     mkdir "$HOME/.nix-defexpr"
     if [ "$USER" != root ]; then
@@ -65,5 +66,5 @@ if [ -w "$HOME" ]; then
 
   # Make sure nix-channel --update works
   SSL_CERT_FILE=/nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
-  CURL_CA_BUNDLE=$SSL_CERT_FILE
+  export CURL_CA_BUNDLE=$SSL_CERT_FILE
 fi

--- a/nix/setup.sh
+++ b/nix/setup.sh
@@ -127,7 +127,7 @@ for n in $(seq 1 10); do
 		-d /var/empty \
 		-g "$GROUP" \
 		-G "$GROUP" \
-		-M -N -r -s "$(which nologin)" \
+		-M -N -r -s "$(command -v nologin)" \
     "$username";
 done
 

--- a/nix/templates/backend-json-api/hooks/post_gen_project.sh
+++ b/nix/templates/backend-json-api/hooks/post_gen_project.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 silent() {
-  out=`$@ 2>&1` || echo $out
+  out=$("$@" 2>&1) || echo "$out"
 }
 
 ln -s ../../nix/requirements_override.nix ./

--- a/please
+++ b/please
@@ -6,7 +6,7 @@ set -eu
 #set -x
 
 silent() {
-  out=`$@ 2>&1` || echo $out
+  out=$("$@" 2>&1) || echo "$out"
 }
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -27,13 +27,14 @@ if uname -a | grep -q Darwin; then
 fi
 
 if [ "$USE_NIX" = "1" ]; then
-  drv=`nix-instantiate nix/default.nix -A please-cli` 2> /dev/null
-  nix_store_file=`cat $drv | cut -c17-91`
+  drv=$(nix-instantiate nix/default.nix -A please-cli) 2> /dev/null
+  nix_store_file=$(cut -c17-91 < "$drv")
   building_please_cli=0
-  if [ ! -e $nix_store_file ]; then
+  if [ ! -e "$nix_store_file" ]; then
     building_please_cli=1
-    echo -n " => Building please command (this might take a minute or two the first time) ... ";
+    printf " => Building please command (this might take a minute or two the first time) ... ";
   fi
+
   silent nix-build nix/default.nix -A please-cli -o result-please-cli;
   if [ "$building_please_cli" = "1" ]; then
     echo "${GREEN}DONE${NC}";
@@ -42,24 +43,24 @@ if [ "$USE_NIX" = "1" ]; then
 
 else
   if [ "$USE_DOCKER" = "1" ]; then
-    DOCKER_HASH="`pwd``git rev-parse --abbrev-ref HEAD`"
-    DOCKER_NAME="mozilla-releng-services-v`cat ./VERSION`-`echo -n $DOCKER_HASH | $SHASUM | cut -d ' ' -f 1`"
-    if [ ! "$(docker ps -q -f name=$DOCKER_NAME)" ]; then
-      if [ ! "$(docker ps -qa -f name=$DOCKER_NAME)" ]; then
+    DOCKER_HASH="$(pwd)$(git rev-parse --abbrev-ref HEAD)"
+    DOCKER_NAME="mozilla-releng-services-v$(cat ./VERSION)-$(printf "%s" "$DOCKER_HASH" | $SHASUM | cut -d ' ' -f 1)"
+    if [ ! "$(docker ps -q -f name="$DOCKER_NAME")" ]; then
+      if [ ! "$(docker ps -qa -f name="$DOCKER_NAME")" ]; then
         docker run \
             --privileged \
             -td \
-            --name $DOCKER_NAME \
+            --name "$DOCKER_NAME" \
             --volume="$(pwd)":/app \
             --volume=/var/run/docker.sock:/var/run/docker.sock \
             --workdir=/app \
             --network="host" \
-            mozillareleng/services:base-`cat ./VERSION`
+            "mozillareleng/services:base-$(cat ./VERSION)"
       else
-        docker start $DOCKER_NAME
+        docker start "$DOCKER_NAME"
       fi
    fi
-   docker exec --tty --interactive --privileged $DOCKER_NAME ./please $@
+   docker exec --tty --interactive --privileged "$DOCKER_NAME" ./please "$@"
    # TODO: stop old docker instances
   else
     # TODO: better error message and point to documentation


### PR DESCRIPTION
Prevent masking of exit code:
```
-export USER=`whoami`
+USER=$(whoami)
+export USER
```

`-o` -> `||` as `-o` can have undefined behaviour

`which` -> `command -v` as which is not guaranteed to be present.

`echo -n` -> `printf` because echo in `sh` doesn't have flags.

Some quoting and redirection fixes.