### PR TITLE
Bug 1492033 - partner repacks should be enabled for ESR60

### DIFF
--- a/src/shipit/api/shipit_api/models.py
+++ b/src/shipit/api/shipit_api/models.py
@@ -16,6 +16,7 @@ import shipit_api.config
 from backend_common.db import db
 from cli_common.log import get_logger
 from shipit_api.release import bump_version
+from shipit_api.release import is_eme_free_enabled
 from shipit_api.release import is_partner_enabled
 from shipit_api.tasks import extract_our_flavors
 from shipit_api.tasks import fetch_actions_json
@@ -167,8 +168,9 @@ class Release(db.Model):
             'release_eta': self.release_eta
         }
         if not is_partner_enabled(self.product, self.version):
-            input_common['release_enable_emefree'] = False
             input_common['release_enable_partners'] = False
+        if not is_eme_free_enabled(self.product, self.version):
+            input_common['release_enable_emefree'] = False
 
         if self.partial_updates:
             input_common['partial_updates'] = {}

--- a/src/shipit/api/shipit_api/release.py
+++ b/src/shipit/api/shipit_api/release.py
@@ -76,9 +76,21 @@ def get_beta_num(version):
         return int(parts[-1])
 
 
-def is_partner_enabled(product, version, min_version=61):
+def is_partner_enabled(product, version, min_version=60):
     major_version = int(version.split('.')[0])
     if product == 'firefox' and major_version >= min_version:
+        if is_beta(version):
+            if get_beta_num(version) >= 8:
+                return True
+        elif is_esr(version):
+            return True
+        else:
+            return True
+    return False
+
+
+def is_eme_free_enabled(product, version):
+    if product == 'firefox':
         if is_beta(version):
             if get_beta_num(version) >= 8:
                 return True

--- a/src/shipit/api/tests/test_release.py
+++ b/src/shipit/api/tests/test_release.py
@@ -7,8 +7,10 @@ import pytest
 
 from shipit_api.release import bump_version
 from shipit_api.release import is_beta
+from shipit_api.release import is_eme_free_enabled
 from shipit_api.release import is_esr
 from shipit_api.release import is_final_release
+from shipit_api.release import is_partner_enabled
 from shipit_api.release import is_rc
 
 
@@ -68,5 +70,32 @@ def test_is_rc(version, partial_updates, result):
     ('45.0.1esr', '45.0.2esr'),
     ('45.2.1esr', '45.2.2esr'),
 ))
-def test_bump_verison(version, result):
+def test_bump_version(version, result):
     assert bump_version(version) == result
+
+
+@pytest.mark.parametrize('product, version, result', (
+    ('firefox', '59.0', False),
+    ('firefox', '65.0b3', False),
+    ('firefox', '65.0b8', True),
+    ('firefox', '65.0', True),
+    ('firefox', '65.0.1', True),
+    ('firefox', '60.5.0esr', True),
+    ('fennec', '65.0b8', False),
+    ('fennec', '65.0', False),
+))
+def test_is_partner_enabled(product, version, result):
+    assert is_partner_enabled(product, version) == result
+
+
+@pytest.mark.parametrize('product, version, result', (
+    ('firefox', '65.0b3', False),
+    ('firefox', '65.0b8', True),
+    ('firefox', '65.0', True),
+    ('firefox', '65.0.1', True),
+    ('firefox', '60.5.0esr', False),
+    ('fennec', '65.0b8', False),
+    ('fennec', '65.0', False),
+))
+def test_is_eme_free_enabled(product, version, result):
+    assert is_eme_free_enabled(product, version) == result


### PR DESCRIPTION
I'm still working on other parts of bug 1492033 but wanted to get this up for comment. We'll need partner repacks on for b8 and higher, release, and esr, which I've expressed as not b1-b7.