### PR TITLE
staticanalysis/bot: Fix many strange false positives in BEFORE_AFTER heuristic.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/workflow.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflow.py
@@ -210,15 +210,12 @@ class Workflow(object):
 
         self.index(revision, state='analyzing')
         with stats.api.timer('runtime.issues'):
-            # Detect initial issues (and clean up again)
+            # Detect initial issues
             if settings.publication == Publication.BEFORE_AFTER:
                 before_patch = self.detect_issues(analyzers, revision)
                 logger.info('Detected {} issue(s) before patch'.format(len(before_patch)))
                 stats.api.increment('analysis.issues.before', len(before_patch))
-
                 revision.reset()
-                self.hg.revert(settings.repo_dir.encode('utf-8'), all=True)
-                logger.info('Reverted all uncommitted changes in repo', rev=self.hg.identify())
 
             # Apply patch
             revision.apply(self.hg)
@@ -273,7 +270,17 @@ class Workflow(object):
             analyzer = analyzer_class()
 
             # Run analyzer on revision and store generated issues
-            issues += analyzer.run(revision)
+            analyzer_issues = analyzer.run(revision)
+
+            # Clean up any uncommitted changes left behind by this analyzer.
+            self.hg.revert(settings.repo_dir.encode('utf-8'), all=True)
+            logger.info('Reverted all uncommitted changes in repo', rev=self.hg.identify())
+
+            # Compute line hashes now before anything else changes the code.
+            for issue in analyzer_issues:
+                issue.build_lines_hash()
+
+            issues += analyzer_issues
 
         return issues
 


### PR DESCRIPTION
Fixes #1722.

Explanation from IRC:

> 14:33:29 janx> marco, bastien: wow, I think I finally understood the "race condition" with before/after and debug logs
> 14:34:15 janx> `issue.lines_hash` is memoized, and only computed when you call `issue.__hash__()`. To compute it, it opens the file, and hashes the content of the line
> 14:35:06 janx> in before/after, we first create a collection of issues, then *apply the patch*, and create another collection of issues, and then we compare the two collections by computing the hashes
> 14:35:43 janx> but it's too late to compute the correct hashes for the first collection of issues (the "before_issues"), because we've already applied a patch and potentially changed the content of the lines it will try to hash
> 14:36:42 janx> that was a big "aha!" moment