### PR TITLE
shipit/api: do not iterate over None

### DIFF
--- a/src/shipit/api/shipit_api/release.py
+++ b/src/shipit/api/shipit_api/release.py
@@ -51,9 +51,10 @@ def is_rc(version, partial_updates):
         # The assumption that "shipping to beta channel" always
         # implies other RC behaviour is bound to break at some
         # point, but this works for now.
-        for version in partial_updates:
-            if is_beta(version):
-                return True
+        if partial_updates:
+            for version in partial_updates:
+                if is_beta(version):
+                    return True
     return False
 
 


### PR DESCRIPTION
This fixes the case when we have no partials (Fennec) but stil want to
use the `is_rc()` function