### PR TITLE
cli_common: mark artifact as completed when uploaded manually

### DIFF
--- a/lib/cli_common/cli_common/taskcluster.py
+++ b/lib/cli_common/cli_common/taskcluster.py
@@ -222,5 +222,17 @@ def create_blob_artifact(queue_service, task_id, run_id, path, content, content_
     )
     push.raise_for_status()
 
+    # Mark artifact as completed
+    queue_service.completeArtifact(
+        task_id,
+        run_id,
+        path,
+        {
+            'etags': [
+                push.headers['ETag'],
+            ],
+        }
+    )
+
     # Build the absolute url
     return f'https://queue.taskcluster.net/v1/task/{task_id}/runs/{run_id}/artifacts/{path}'

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -107,21 +107,6 @@ def main(source,
         taskcluster_access_token,
     )
 
-    # TRASHME, this is a TEST
-    from cli_common.taskcluster import create_blob_artifact
-    from datetime import timedelta
-    url = create_blob_artifact(
-        queue_service,
-        settings.taskcluster.task_id,
-        settings.taskcluster.run_id,
-        'public/test.txt',
-        'This is a test.',
-        'text/plain',
-        timedelta(days=1),
-    )
-    print(url)
-    return
-
     # Load Phabricator API
     phabricator_api = PhabricatorAPI(**secrets['PHABRICATOR'])
     if 'phabricator' in reporters:

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -107,6 +107,21 @@ def main(source,
         taskcluster_access_token,
     )
 
+    # TRASHME, this is a TEST
+    from cli_common.taskcluster import create_blob_artifact
+    from datetime import timedelta
+    url = create_blob_artifact(
+        queue_service,
+        settings.taskcluster.task_id,
+        settings.taskcluster.run_id,
+        'public/test.txt',
+        'This is a test.',
+        'text/plain',
+        timedelta(days=1),
+    )
+    print(url)
+    return
+
     # Load Phabricator API
     phabricator_api = PhabricatorAPI(**secrets['PHABRICATOR'])
     if 'phabricator' in reporters:


### PR DESCRIPTION
This is needed by Taskcluster so that docker-worker gets the "done" status.

Fixes #1755 