### PR TITLE
Remove autophone from trychooser

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -350,33 +350,6 @@
             <li><label><input type="checkbox" value="xpcshell-1">xpcshell-1</label></li>
             <li><label><input type="checkbox" value="xpcshell-2">xpcshell-2</label></li>
             <li><label><input type="checkbox" value="xpcshell-3">xpcshell-3</label></li>
-            <li><label><input type="checkbox" value="autophone-crashtest-dom-media">autophone-crashtest-dom-media (Cdm1)</label></li>
-            <li><label><input type="checkbox" value="autophone-crashtest-dom-media-tests">autophone-crashtest-dom-media-tests (Cdm2)</label></li>
-            <li><label><input type="checkbox" value="autophone-crashtest-dom-media-mediasource">autophone-crashtest-dom-media-mediasource (Cdm3)</label></li>
-            <li><label><input type="checkbox" value="autophone-crashtest-dom-media-webspeech-synth">autophone-crashtest-dom-media-webspeech-synth (Cdm4)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-browser-element">autophone-mochitest-dom-browser-element (Mdb)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-media">autophone-mochitest-dom-media (Mdm1)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-media-tests">autophone-mochitest-dom-media-tests (Mdm2)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-media-mediasource">autophone-mochitest-dom-media-mediasource (Mdm3)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-media-tests-identity">autophone-mochitest-dom-media-tests-identity (Mdm4)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-media-webaudio">autophone-mochitest-dom-media-webaudio (Mdm5)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-media-webaudio-blink">autophone-mochitest-dom-media-blink (Mdm6)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-media-webspeech-recognition">autophone-mochitest-dom-media-webspeech-recognition (Mdm7)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-media-webspeech-synth">autophone-mochitest-dom-media-webspeech-synth (Mdm8)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-dom-media-webspeech-synth-startup">autophone-mochitest-dom-media-webspeech-synth-startup (Mdm9)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-geckoview-e10s">autophone-mochitest-geckoview-e10s (Mg)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-skia">autophone-mochitest-skia (Msk)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-toolkit-widgets">autophone-mochitest-toolkit-widgets (Mtw)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-webgl">autophone-mochitest-webgl-conf (glm)</label></li>
-            <li><label><input type="checkbox" value="autophone-mochitest-webgl-conf">autophone-mochitest-webgl-conf (gl)</label></li>
-            <li><label><input type="checkbox" value="autophone-reftest-ogg-video">autophone-reftest-ogg-video (Rov)</label></li>
-            <li><label><input type="checkbox" value="autophone-reftest-webm-video">autophone-reftest-webm-video (Rwv)</label></li>
-            <li><label><input type="checkbox" value="autophone-robocoptest-autophone2">autophone-robocoptest-autophone2 (rca2)</label></li>
-            <li><label><input type="checkbox" value="autophone-s1s2">autophone-s1s2 (t)</label></li>
-            <li><label><input type="checkbox" value="autophone-s1s2geckoview">autophone-s1s2geckoview (tg)</label></li>
-            <li><label><input type="checkbox" value="autophone-s1s2geckoview-e10s">autophone-s1s2geckoview-e10s (tg)</label></li>
-            <li><label><input type="checkbox" value="autophone-smoketest">autophone-smoketest (s)</label></li>
-            <li><label><input type="checkbox" value="autophone-talos">autophone-talos (tpn, svg)</label></li>
             </ul>
             </div>
         </div> <!-- col2 div -->


### PR DESCRIPTION
Bug 1515961 - Remove autophone from trychooser, r=garbas

Autophone has been decommissioned and all Android hardware testing uses mozharness based frameworks. Try syntax usage for submitting Android hardware tests was disabled in Bug 1515599 with only mach try fuzzy now supported.

We can therefore remove autophone from trychooser and eliminate confusion about its availability.