### PR TITLE
please_cli: fix quotes

### DIFF
--- a/please
+++ b/please
@@ -22,7 +22,7 @@ fi
 
 # Detect OSX
 SHASUM="sha256sum"
-NETWORK_OPTIONS='--network="host"'
+NETWORK_OPTIONS=--network="host"
 if uname -a | grep -q Darwin; then
     SHASUM="shasum -a 256"
     # Binding to 127.0.0.1 doesn't work on macosx


### PR DESCRIPTION
I started getting this message after recent changes:

```
Error response from daemon: network "host" not found
```

After some debugging I found that the constructed command line contains
single quotes:

```
docker run --privileged -td ... '--network="host"' mozillareleng/services:base-52
```

With single quotes removed, it runs as expected.