### PR TITLE
shipit/api: action hook support

### DIFF
--- a/src/shipit/api/shipit_api/config.py
+++ b/src/shipit/api/shipit_api/config.py
@@ -417,22 +417,22 @@ MOBILE_DETAILS_TEMPLATE = r'''
 # TODO: add other branches
 # TODO: consider move this to secrets, aka per env config
 SIGNOFFS = {
-    'projects/maple': {
-        'fennec': {
-            'ship_fennec': [
-                {
-                    'name': '[relman] Ship Fennec',
-                    'description': 'Publish Firefox for Android to Play Store',
-                    # TODO: this group includes releng/relman/qa/etc, need to split or switch to real scopes
-                    'permissions': 'vpn_cloudops_shipit',
-                },
-                {
-                    'name': '[releng] Ship Fennec',
-                    'description': 'Publish Firefox for Android to Play Store',
-                    # XXX: stands for the LDAP group for now
-                    'permissions': 'releng',
-                },
-            ],
-        },
-    },
+    # 'projects/maple': {
+    #     'fennec': {
+    #         'ship_fennec': [
+    #             {
+    #                 'name': '[relman] Ship Fennec',
+    #                 'description': 'Publish Firefox for Android to Play Store',
+    #                 # TODO: this group includes releng/relman/qa/etc, need to split or switch to real scopes
+    #                 'permissions': 'vpn_cloudops_shipit',
+    #             },
+    #             {
+    #                 'name': '[releng] Ship Fennec',
+    #                 'description': 'Publish Firefox for Android to Play Store',
+    #                 # XXX: stands for the LDAP group for now
+    #                 'permissions': 'releng',
+    #             },
+    #         ],
+    #     },
+    # },
 }


### PR DESCRIPTION
This adds support for handling both action kinds (task and hook). The
unusual part was that we cannot pre-set the action hook generated
taskId, we have to update it dynamically (in the DB and the input).

I tested it in staging only using Fennec (Firefox partials won't cooperate). Example generated action tasks for [promote_fennec](https://tools.taskcluster.net/groups/eqxzMBpHQX-dChVcPBcpFg/tasks/QDp9Cuj5TQ6h8UqS0Hp3yA/details) and [ship_fennec](https://tools.taskcluster.net/groups/eqxzMBpHQX-dChVcPBcpFg/tasks/JsO9MB3uT1K4hDVbollz8w/details). The values of `previous_graph_ids` look sane to me.