### PR TITLE
[WIP] codecoverage/bot: Remove now useless 'changeset' parameter from phabricator module

### DIFF
--- a/src/codecoverage/bot/code_coverage_bot/codecov.py
+++ b/src/codecoverage/bot/code_coverage_bot/codecov.py
@@ -191,7 +191,7 @@ class CodeCov(object):
         logger.info('Report generated successfully')
 
         logger.info('Upload changeset coverage data to Phabricator')
-        phabricatorUploader.upload(json.loads(output), changesets)
+        phabricatorUploader.upload(json.loads(output))
 
     # This function is executed when the bot is triggered via cron.
     def go_from_cron(self):

--- a/src/codecoverage/bot/code_coverage_bot/phabricator.py
+++ b/src/codecoverage/bot/code_coverage_bot/phabricator.py
@@ -77,12 +77,11 @@ class PhabricatorUploader(object):
 
         return phab_coverage_data
 
-    def generate(self, report, changesets=None):
+    def generate(self, report):
         results = {}
 
         with hgmo.HGMO(self.repo_dir) as hgmo_server:
-            if changesets is None:
-                changesets = hgmo_server.get_automation_relevance_changesets(self.revision)
+            changesets = hgmo_server.get_automation_relevance_changesets(self.revision)
 
             for changeset in changesets:
                 # Retrieve the revision ID for this changeset.
@@ -121,8 +120,8 @@ class PhabricatorUploader(object):
 
         return results
 
-    def upload(self, report, changesets=None):
-        results = self.generate(report, changesets)
+    def upload(self, report):
+        results = self.generate(report)
 
         if secrets[secrets.PHABRICATOR_ENABLED]:
             phabricator = PhabricatorAPI(secrets[secrets.PHABRICATOR_TOKEN], secrets[secrets.PHABRICATOR_URL])


### PR DESCRIPTION
Depends on #1786.

WIP because I need to figure out an error that occurs when using json-automationrelevance with a changeset from the try repository.