### PR TITLE
codecoverage/bot: Make getting chunks platform-specific, as some chunks are only available in a platform and not in another

### DIFF
--- a/src/codecoverage/bot/code_coverage_bot/artifacts.py
+++ b/src/codecoverage/bot/code_coverage_bot/artifacts.py
@@ -29,8 +29,8 @@ class ArtifactsHandler(object):
         file_name = '%s_%s_%s' % (platform, chunk, os.path.basename(artifact['name']))
         return os.path.join(self.parent_dir, file_name)
 
-    def get_chunks(self):
-        return list(set([f.split('_')[1] for f in os.listdir(self.parent_dir)]))
+    def get_chunks(self, platform):
+        return set(f.split('_')[1] for f in os.listdir(self.parent_dir) if os.path.basename(f).startswith(f'{platform}_'))
 
     def get(self, platform=None, suite=None, chunk=None):
         files = os.listdir(self.parent_dir)

--- a/src/codecoverage/bot/code_coverage_bot/chunk_mapping.py
+++ b/src/codecoverage/bot/code_coverage_bot/chunk_mapping.py
@@ -167,14 +167,18 @@ def generate(repo_dir, revision, artifactsHandler, out_dir='.'):
             futures = {}
             for platform in PLATFORMS:
                 logger.info('Reading chunk coverage artifacts for {}.'.format(platform))
-                for chunk in artifactsHandler.get_chunks():
+                for chunk in artifactsHandler.get_chunks(platform):
                     suite = taskcluster.get_suite(chunk)
                     if not is_chunk_only_suite(suite):
                         continue
 
                     assert chunk.strip() != '', 'chunk can not be an empty string'
 
-                    future = executor.submit(grcov.files_list, artifactsHandler.get(platform=platform, chunk=chunk), source_dir=repo_dir)
+                    artifacts = artifactsHandler.get(platform=platform, chunk=chunk)
+
+                    assert len(artifacts) > 0, 'There should be at least one artifact'
+
+                    future = executor.submit(grcov.files_list, artifacts, source_dir=repo_dir)
                     futures[future] = (platform, chunk)
 
                 logger.info('Populating chunk_to_test table for {}.'.format(platform))

--- a/src/codecoverage/bot/tests/test_artifacts.py
+++ b/src/codecoverage/bot/tests/test_artifacts.py
@@ -37,10 +37,13 @@ def test_generate_path(FAKE_ARTIFACTS_DIR):
 
 def test_get_chunks(FAKE_ARTIFACTS_DIR):
     a = ArtifactsHandler([], parent_dir=FAKE_ARTIFACTS_DIR)
-    assert set(a.get_chunks()) == set([
-        'mochitest-1', 'mochitest-2', 'xpcshell-3', 'xpcshell-7',
-        'cppunit', 'firefox-ui-functional-remote',
-    ])
+    assert a.get_chunks('windows') == {
+        'mochitest-1', 'xpcshell-7', 'cppunit',
+    }
+    assert a.get_chunks('linux') == {
+        'mochitest-2', 'xpcshell-3', 'xpcshell-7',
+        'firefox-ui-functional-remote',
+    }
 
 
 def test_get_coverage_artifacts(FAKE_ARTIFACTS_DIR):

--- a/src/codecoverage/bot/tests/test_chunk_mapping.py
+++ b/src/codecoverage/bot/tests/test_chunk_mapping.py
@@ -16,8 +16,8 @@ def fake_artifacts_handler(grcov_artifact, jsvm_artifact, grcov_existing_file_ar
         def __init__(self):
             pass
 
-        def get_chunks(self):
-            return ['chunk1', 'chunk2']
+        def get_chunks(self, platform):
+            return {'chunk1', 'chunk2'}
 
         def get(self, platform=None, suite=None, chunk=None):
             if platform == 'linux' and chunk == 'chunk1':


### PR DESCRIPTION
For example, the entire 'robocop' test suite is available only for Android.
Moreover, some test suites are divided in a smaller/higher number of chunks according to platform (e.g. on Linux we have less chunks than on Windows, as Windows is slower).