### PR TITLE
pulselistener: Don't warn on skipped messages

### DIFF
--- a/src/pulselistener/pulselistener/hook.py
+++ b/src/pulselistener/pulselistener/hook.py
@@ -91,13 +91,12 @@ class PulseHook(Hook):
 
         # Parse payload
         env = self.parse(body)
-        if env is None:
-            logger.warn('Skipping message, no task created', hook=self.hook_id)
-        elif isinstance(env, list):
-            for e in env:
-                await self.create_task(extra_env=e)
-        else:
-            raise Exception('Unsupported env type')
+        if env is not None:
+            if isinstance(env, list):
+                for e in env:
+                    await self.create_task(extra_env=e)
+            else:
+                raise Exception('Unsupported env type')
 
         # Ack the message so it is removed from the broker's queue
         await channel.basic_client_ack(delivery_tag=envelope.delivery_tag)


### PR DESCRIPTION
Not all pulse messages are supposed to start a task, `parse` returning None is just a way to say "skip this message as it is not relevant", so it's harmless.