### PR TITLE
Add Android x86_64 and Windows/aarch64 that are tier-1 platfrom

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -99,6 +99,9 @@
                 <label><input type="checkbox" name="platform" value="win64-ccov" class="nondefault">win64 code coverage</label>
             </li>
             <li>
+                <label><input type="checkbox" name="platform" value="win64-aarch64-msvc">win64-aarch64 msvc</label>
+            </li>
+            <li>
                 <label><input type="checkbox" name="platform" value="android-api-16">android api-16+</label>
             </li>
             <li>
@@ -106,6 +109,9 @@
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="android-aarch64">android-aarch64 (Android 5.0)</label>
+            </li>
+            <li>
+                <label><input type="checkbox" name="platform" value="android-x86_64">android-x86_64</label>
             </li>
             <li>
                 <label><input type="checkbox" name="platform" value="sm-arm-sim-linux32">Spidermonkey ARM32 simulator</label>


### PR DESCRIPTION
Now android/x86-64 and win64/aarch64 are tier-1 platform, so try chooser should have a option for this platforms.