### PR TITLE
Unittest for coverage_supported

### DIFF
--- a/src/codecoverage/backend/tests/test_coverage.py
+++ b/src/codecoverage/backend/tests/test_coverage.py
@@ -21,6 +21,7 @@ def test_coverage_supported_extensions_api(client):
         'hxx', 'js', 'jsm', 'xul', 'xml', 'html', 'xhtml',
     ])
 
+
 def test_coverage_supported_extensions():
     # Positive and negative tests for supported extensions
     from codecoverage_backend.coverage import coverage_supported
@@ -28,6 +29,7 @@ def test_coverage_supported_extensions():
     assert coverage_supported(supported_path)
     unsupported_path = '/path/to/file.xyz'
     assert not coverage_supported(unsupported_path)
+
 
 @pytest.mark.asyncio
 async def test_coverage_latest(coverage_responses):

--- a/src/codecoverage/backend/tests/test_coverage.py
+++ b/src/codecoverage/backend/tests/test_coverage.py
@@ -21,6 +21,13 @@ def test_coverage_supported_extensions_api(client):
         'hxx', 'js', 'jsm', 'xul', 'xml', 'html', 'xhtml',
     ])
 
+def test_coverage_supported_extensions():
+    # Positive and negative tests for supported extensions
+    from codecoverage_backend.coverage import coverage_supported
+    supported_path = '/path/to/file.cpp'
+    assert coverage_supported(supported_path)
+    unsupported_path = '/path/to/file.xyz'
+    assert not coverage_supported(unsupported_path)
 
 @pytest.mark.asyncio
 async def test_coverage_latest(coverage_responses):


### PR DESCRIPTION
Signed-off-by: mandaltapesh <tapesh.mandal@hotmail.com>

The added test function, test_coverage_supported_extensions,  aims to improve the unit test coverage for coverage.py by making a function call to coverage_supported function. It returns True for a path with a valid extension and False if not. So there are two scenarios covered in the unittest one positive (a path with a valid extension) and one negative (a path without a valid extension). And existing test function, test_coverage_supported_extensions_api, which checked for all the supported extensions by making an API call, hence I believe it didn't contribute to unittest coverage.