### PR TITLE
please_cli: explicitly define stable tags

### DIFF
--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -900,6 +900,7 @@ PROJECTS_CONFIG = {
                         'nix_path_attribute': 'dockerflow',
                         'docker_registry': 'index.docker.io',
                         'docker_repo': 'mozilla/shipitbackend',
+                        'docker_stable_tag': 'shipit-api-shipit-api.dockerflow-testing',
                     },
                     'staging': {
                         'enable': True,
@@ -907,6 +908,7 @@ PROJECTS_CONFIG = {
                         'nix_path_attribute': 'dockerflow',
                         'docker_registry': 'index.docker.io',
                         'docker_repo': 'mozilla/shipitbackend',
+                        'docker_stable_tag': 'shipit-api-shipit-api.dockerflow-staging',
                     },
                     'production': {
                         'enable': True,
@@ -916,6 +918,38 @@ PROJECTS_CONFIG = {
                         'nix_path_attribute': 'dockerflow',
                         'docker_registry': 'index.docker.io',
                         'docker_repo': 'mozilla/shipitbackend',
+                        'docker_stable_tag': 'shipit-api-shipit-api.dockerflow-production',
+                    },
+                },
+            },
+            {
+                'target': 'DOCKERHUB',
+                'options': {
+                    'testing': {
+                        'enable': True,
+                        'url': 'https://api.shipit.testing.mozilla-releng.net',
+                        'nix_path_attribute': 'dockerflow',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozilla/release-services',
+                        'docker_stable_tag': 'shipit_api_dockerflow_testing',
+                    },
+                    'staging': {
+                        'enable': True,
+                        'url': 'https://api.shipit.staging.mozilla-releng.net',
+                        'nix_path_attribute': 'dockerflow',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozilla/release-services',
+                        'docker_stable_tag': 'shipit_api_dockerflow_staging',
+                    },
+                    'production': {
+                        'enable': True,
+                        # TODO: we will switch to new url soon
+                        # 'url': 'https://api.shipit.mozilla-releng.net',
+                        'url': 'https://shipit-api.mozilla-releng.net',
+                        'nix_path_attribute': 'dockerflow',
+                        'docker_registry': 'index.docker.io',
+                        'docker_repo': 'mozilla/release-services',
+                        'docker_stable_tag': 'shipit_api_dockerflow_production',
                     },
                 },
             },

--- a/lib/please_cli/please_cli/decision_task.py
+++ b/lib/please_cli/please_cli/decision_task.py
@@ -182,8 +182,10 @@ def get_deploy_task(index,
         try:
             docker_registry = deploy_options['docker_registry']
             docker_repo = deploy_options['docker_repo']
+            docker_stable_tag = deploy_options['docker_stable_tag']
         except KeyError:
-            raise click.ClickException('Missing `docker_registry` or `docker_repo` in deploy options')
+            raise click.ClickException(
+                'Missing `docker_registry` or `docker_repo` or `docker_stable_tag` in deploy options')
 
         project_name = (
             f'{project} ({nix_path_attribute}) to DOCKERHUB '
@@ -196,6 +198,7 @@ def get_deploy_task(index,
             f'--docker-repo={docker_repo}',
             f'--docker-registry={docker_registry}',
             f'--channel={channel}',
+            f'--docker-stable-tag={docker_stable_tag}',
             '--no-interactive',
         ]
 

--- a/lib/please_cli/please_cli/deploy.py
+++ b/lib/please_cli/please_cli/deploy.py
@@ -565,9 +565,9 @@ def cmd_TASKCLUSTER_HOOK(ctx,
     help='Docker password.',
     )
 @click.option(
-    '--docker-image-tag-format',
-    default='{project}-{nix_path_attribute}-{channel}',
-    help='Docker image tag format. Accepted templates: {project}, {nix_path_attribute}, {channel}',
+    '--docker-stable-tag',
+    required=True,
+    help='Docker image tag that we overwrite with every push. Helps tracking a project using a single tag',
     )
 @click.option(
     '--interactive/--no-interactive',
@@ -587,7 +587,7 @@ def cmd_DOCKERHUB(ctx,
                   docker_username,
                   docker_password,
                   docker_repo,
-                  docker_image_tag_format,
+                  docker_stable_tag,
                   interactive,
                   ):
     '''Push to Docker Hub.
@@ -625,13 +625,9 @@ def cmd_DOCKERHUB(ctx,
         project_basename = os.path.basename(project_path)
         # remove the docker-image-mozilla- prefix and the extension
         tag_base = project_basename.replace('docker-image-mozilla-', '').replace('.tar.gz', '')
-        # Puth the hash to the end of the tag
+        # Put the hash to the end of the tag
         image_tag_versioned = '-'.join(reversed(tag_base.split('-', 1)))
-        # Stable tag, e.g. shipit-api-staging
-        image_tag = docker_image_tag_format.format(project=project.replace('/', '-'),
-                                                   nix_path_attribute=nix_path_attribute.replace('/', '-'),
-                                                   channel=channel)
-        for tag in (image_tag_versioned, image_tag):
+        for tag in (image_tag_versioned, docker_stable_tag):
             click.echo(' => Uploading docker image `{}:{}` ... '.format(docker_repo, tag), nl=False)
             with click_spinner.spinner():
                 please_cli.utils.push_docker_image(


### PR DESCRIPTION
Simplify how we specify stable docker tags by removing the code that
tries to guess the name :)

Explicit is better than semi-implicit.

Closes #1813