### PR TITLE
staticanalysis/bot: Run clang-format on each file from the patch

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/clang/format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/format.py
@@ -83,7 +83,6 @@ class ClangFormat(object):
             os.path.join(settings.repo_dir, path).encode('utf-8')  # needed for hglib
             for path in filter(settings.is_allowed_path, revision.files)
         ]
-
         client = hglib.open(settings.repo_dir)
         self.diff = client.diff(files=allowed_paths, unified=8).decode('utf-8')
 

--- a/src/staticanalysis/bot/tests/conftest.py
+++ b/src/staticanalysis/bot/tests/conftest.py
@@ -274,7 +274,7 @@ def mock_clang(mock_config, tmpdir, monkeypatch):
             res.stdout = res.stdout + b'\n42 warnings present.'
             return res
 
-        if command[:5] == ['gecko-env', './mach', '--log-no-times', 'clang-format']:
+        if command[:4] == ['gecko-env', './mach', '--log-no-times', 'clang-format']:
             # Mock ./mach clang-format behaviour by analysing repo bad file
             # with the embedded clang-format from Nix
             # and replace this file with the output


### PR DESCRIPTION
The purpose of this PR is to run clang-format of every file from the patch instead of running it on the diff.

For more details on why we want this behaviour please see https://github.com/mozilla/release-services/issues/1815

Fixes #1815.