### PR TITLE
codecoverage/bot: Turn missing files assertion into a warning for now

### DIFF
--- a/src/codecoverage/bot/code_coverage_bot/codecov.py
+++ b/src/codecoverage/bot/code_coverage_bot/codecov.py
@@ -137,15 +137,19 @@ class CodeCov(object):
         r.raise_for_status()
         push_id = r.json()['pushid']
 
+        # Check that all JavaScript files present in the coverage artifacts actually exist.
+        # If they don't, there might be a bug in the LCOV rewriter.
         for artifact in self.artifactsHandler.get():
             if 'jsvm' not in artifact:
                 continue
+
             with zipfile.ZipFile(artifact, 'r') as zf:
                 for file_name in zf.namelist():
                     with zf.open(file_name, 'r') as fl:
                         source_files = [line[3:].decode('utf-8').rstrip() for line in fl if line.startswith(b'SF:')]
                         missing_files = [f for f in source_files if not os.path.exists(os.path.join(self.repo_dir, f))]
-                        assert len(missing_files) == 0, f'{missing_files} are missing'
+                        if len(missing_files) != 0:
+                            logger.warn(f'{missing_files} are present in coverage reports, but missing from the repository')
 
         output = grcov.report(
             self.artifactsHandler.get(),


### PR DESCRIPTION
Unfortunately we can't assert yet, as there are problems.
In the latest run:

AssertionError: ['obj-firefox/devtools/client/debugger/new/src/components/SecondaryPanes/Frames/index.js', 'obj-firefox/devtools/client/debugger/new/src/components/SecondaryPanes/Frames/Frame.js', 'obj-firefox/devtools/client/debugger/new/src/components/shared/AccessibleImage.js', 'obj-firefox/devtools/client/debugger/new/src/components/SecondaryPanes/Frames/FrameMenu.js', 'obj-firefox/devtools/client/debugger/new/src/components/SecondaryPanes/Frames/Group.js', 'obj-firefox/devtools/client/debugger/new/src/components/shared/Badge.js', 'obj-firefox/devtools/client/debugger/new/src/components/SecondaryPanes/Frames/WhyPaused.js', 'obj-firefox/devtools/client/debugger/new/src/utils/connect.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/frames/index.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/frames/annotateFrames.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/frames/getFrameUrl.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/frames/getLibraryFromUrl.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/frames/collapseFrames.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/frames/displayName.js', 'obj-firefox/devtools/client/debugger/new/src/utils/source.js', 'obj-firefox/devtools/client/debugger/new/src/utils/isMinified.js', 'obj-firefox/devtools/client/debugger/new/src/utils/utils.js', 'obj-firefox/devtools/client/debugger/new/src/utils/text.js', 'obj-firefox/devtools/client/debugger/new/src/utils/url.js', 'obj-firefox/devtools/client/debugger/new/src/utils/wasm.js', 'obj-firefox/devtools/client/debugger/new/src/utils/editor/index.js', 'obj-firefox/devtools/client/debugger/new/src/utils/editor/source-documents.js', 'obj-firefox/devtools/client/debugger/new/src/utils/ui.js', 'obj-firefox/devtools/client/debugger/new/src/utils/editor/get-token-location.js', 'obj-firefox/devtools/client/debugger/new/src/utils/editor/source-search.js', 'obj-firefox/devtools/client/debugger/new/src/utils/build-query.js', 'obj-firefox/devtools/client/debugger/new/src/utils/editor/token-events.js', 'obj-firefox/devtools/client/debugger/new/src/utils/editor/create-editor.js', 'obj-firefox/devtools/client/debugger/new/src/utils/prefs.js', 'obj-firefox/devtools/client/debugger/new/src/utils/asyncStoreHelper.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/index.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/addToTree.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/utils.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/getURL.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/treeOrder.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/collapseTree.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/createTree.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/formatTree.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/getDirectories.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/sortTree.js', 'obj-firefox/devtools/client/debugger/new/src/utils/sources-tree/updateTree.js', 'obj-firefox/devtools/client/debugger/new/src/utils/clipboard.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/index.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/why.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/stepping.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/index.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/expressions.js', 'obj-firefox/devtools/client/debugger/new/src/utils/makeRecord.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/sources.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/tabs.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/event-listeners.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/pause.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/debuggee.js', 'obj-firefox/devtools/client/debugger/new/src/utils/workers.js', 'obj-firefox/devtools/client/debugger/new/src/utils/path.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/breakpoints.js', 'obj-firefox/devtools/client/debugger/new/src/utils/breakpoint/index.js', 'obj-firefox/devtools/client/debugger/new/src/utils/breakpoint/astBreakpointLocation.js', 'obj-firefox/devtools/client/debugger/new/src/workers/parser/index.js', 'obj-firefox/devtools/client/debugger/new/src/utils/ast.js', 'obj-firefox/devtools/client/debugger/new/src/utils/assert.js', 'obj-firefox/devtools/client/debugger/new/src/utils/source-maps.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/pending-breakpoints.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/ui.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/file-search.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/ast.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/project-text-search.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/source-tree.js', 'obj-firefox/devtools/client/debugger/new/src/reducers/quick-open.js', 'obj-firefox/devtools/client/debugger/new/src/utils/quick-open.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/breakpointAtLocation.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/visibleBreakpoints.js', 'obj-firefox/devtools/client/debugger/new/src/utils/memoize.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/inComponent.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/isSelectedFrameVisible.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/getCallStackFrames.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/visibleSelectedFrame.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/breakpointSources.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/breakpoints.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/visibleColumnBreakpoints.js', 'obj-firefox/devtools/client/debugger/new/src/selectors/visiblePausePoints.js', 'obj-firefox/devtools/client/debugger/new/src/actions/index.js', 'obj-firefox/devtools/client/debugger/new/src/actions/breakpoints/index.js', 'obj-firefox/devtools/client/debugger/new/src/actions/utils/middleware/promise.js', 'obj-firefox/devtools/client/debugger/new/src/utils/DevToolsUtils.js', 'obj-firefox/devtools/client/debugger/new/src/actions/breakpoints/addBreakpoint.js', 'obj-firefox/devtools/client/debugger/new/src/utils/telemetry.js', 'obj-firefox/devtools/client/debugger/new/src/actions/breakpoints/remapLocations.js', 'obj-firefox/devtools/client/debugger/new/src/actions/breakpoints/syncBreakpoint.js', 'obj-firefox/devtools/client/debugger/new/src/actions/expressions.js', 'obj-firefox/devtools/client/debugger/new/src/utils/expressions.js', 'obj-firefox/devtools/client/debugger/new/src/utils/indentation.js', 'obj-firefox/devtools/client/debugger/new/src/actions/event-listeners.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/index.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/commands.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/fetchScopes.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/mapScopes.js', 'obj-firefox/devtools/client/debugger/new/src/actions/sources/loadSourceText.js', 'obj-firefox/devtools/client/debugger/new/src/utils/defer.js', 'obj-firefox/devtools/client/debugger/new/src/utils/log.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/mapScopes/index.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/mapScopes/locColumn.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/mapScopes/rangeMetadata.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/mapScopes/positionCmp.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/mapScopes/filtering.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/mapScopes/findGeneratedBindingFromPosition.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/mapScopes/mappingContains.js', 'obj-firefox/devtools/client/debugger/new/src/client/firefox.js', 'obj-firefox/devtools/client/debugger/new/src/client/firefox/commands.js', 'obj-firefox/devtools/client/debugger/new/src/client/firefox/create.js', 'obj-firefox/devtools/client/debugger/new/src/client/firefox/workers.js', 'obj-firefox/devtools/client/debugger/new/src/client/firefox/events.js', 'obj-firefox/devtools/client/debugger/new/src/utils/source-queue.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/mapScopes/buildGeneratedBindingList.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/mapScopes/getApplicableBindingsForOriginalPosition.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/paused.js', 'obj-firefox/devtools/client/debugger/new/src/actions/sources/index.js', 'obj-firefox/devtools/client/debugger/new/src/actions/sources/blackbox.js', 'obj-firefox/devtools/client/debugger/new/src/actions/sources/newSources.js', 'obj-firefox/devtools/client/debugger/new/src/actions/sources/prettyPrint.js', 'obj-firefox/devtools/client/debugger/new/src/actions/ast.js', 'obj-firefox/devtools/client/debugger/new/src/actions/tabs.js', 'obj-firefox/devtools/client/debugger/new/src/actions/ast/setInScopeLines.js', 'obj-firefox/devtools/client/debugger/new/src/actions/ast/setPausePoints.js', 'obj-firefox/devtools/client/debugger/new/src/utils/pause/pausePoints.js', 'obj-firefox/devtools/client/debugger/new/src/workers/pretty-print/index.js', 'obj-firefox/devtools/client/debugger/new/src/actions/sources/select.js', 'obj-firefox/devtools/client/debugger/new/src/actions/ui.js', 'obj-firefox/devtools/client/debugger/new/src/actions/file-search.js', 'obj-firefox/devtools/client/debugger/new/src/workers/search/index.js', 'obj-firefox/devtools/client/debugger/new/src/utils/location.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/mapFrames.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/resumed.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/continueToHere.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/breakOnNext.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/setPopupObjectProperties.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/pauseOnExceptions.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/selectFrame.js', 'obj-firefox/devtools/client/debugger/new/src/actions/pause/skipPausing.js', 'obj-firefox/devtools/client/debugger/new/src/actions/navigation.js', 'obj-firefox/devtools/client/debugger/new/src/actions/debuggee.js', 'obj-firefox/devtools/client/debugger/new/src/actions/project-text-search.js', 'obj-firefox/devtools/client/debugger/new/src/actions/quick-open.js', 'obj-firefox/devtools/client/debugger/new/src/actions/source-tree.js', 'obj-firefox/devtools/client/debugger/new/src/actions/toolbox.js', 'obj-firefox/devtools/client/debugger/new/src/actions/preview.js', 'obj-firefox/devtools/client/debugger/new/src/utils/preview.js', 'obj-firefox/devtools/client/debugger/new/src/utils/editor/get-expression.js'] are missing