### PR TITLE
remove obsolete platform linux64-st-an from trychooser

### DIFF
--- a/src/releng_frontend/src/static/trychooser/index.html
+++ b/src/releng_frontend/src/static/trychooser/index.html
@@ -54,9 +54,6 @@
                 <label><input type="checkbox" name="platform" value="linux64-asan">linux64-asan</label>
             </li>
             <li>
-                <label><input type="checkbox" name="platform" value="linux64-st-an">linux64 static analysis</label>
-            </li>
-            <li>
                 <label><input type="checkbox" name="platform" value="linux64-valgrind">linux64 valgrind</label>
             </li>
             <li>


### PR DESCRIPTION
According to Gecko Decision Task in [this tryserver run](https://treeherder.mozilla.org/#/jobs?repo=try&revision=ca2ece7055ae8cd1b1b44f86ec1f6fe7d17a38e5&selectedJob=224804110), "Exception: Unknown platform(s) [linux64-st-an] specified for try," so presumably it's obsolete and should be removed from the trychooser list of platforms.
