### PR TITLE
Change clang-format's command message to show, not apply

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -21,7 +21,7 @@ COMMENT_PARTS = {
     },
     ClangFormatIssue: {
         'defect': ' - {nb} found by clang-format',
-        'analyzer': ' - `./mach clang-format -p path/to/file.cpp` (C/C++)',
+        'analyzer': ' - `./mach clang-format -s -p path/to/file.cpp` (C/C++)',
     },
     MozLintIssue: {
         'defect': ' - {nb} found by mozlint',

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -26,7 +26,7 @@ Code analysis found 1 defect in this patch:
  - 1 defect found by clang-format
 
 You can run this analysis locally with:
- - `./mach clang-format -p path/to/file.cpp` (C/C++)
+ - `./mach clang-format -s -p path/to/file.cpp` (C/C++)
 
 For your convenience, [here is a patch]({results}/clang-format-PHID-DIFF-abcdef.diff) that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply`).
 


### PR DESCRIPTION
`./mach clang-format -p path/to/file.cpp` applies changes silently to the working tree. `COMMENT_FAILURE` says "You can run this analysis locally with:" which to me suggests a "show, don't do" command.

By putting in `-s` that instructs `clang-format` to perform the analysis and show the results instead of silently applying them.

To be clear this doesn't change how clang-format is run against patches, just how it's suggested to be run in the helpful reviewbot message.