### PR TITLE
Revert "tooltool/api: use app.cli.add_command instead of decorator for flask subcommands (#1683)"

### DIFF
--- a/src/tooltool/api/tooltool_api/__init__.py
+++ b/src/tooltool/api/tooltool_api/__init__.py
@@ -3,11 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
-import typing
-
 import flask
+import os
 import werkzeug.exceptions
+import typing
 
 import backend_common
 import backend_common.api
@@ -49,8 +48,16 @@ def create_app(config: dict = None) -> flask.Flask:
     for code, exception in werkzeug.exceptions.default_exceptions.items():
         app.register_error_handler(exception, custom_handle_default_exceptions)
 
-    app.cli.add_command(tooltool_api.cli.cmd_worker, 'worker')
-    app.cli.add_command(tooltool_api.cli.cmd_replicate, 'replicate')
-    app.cli.add_command(tooltool_api.cli.cmd_check_pending_uploads, 'check_pending_uploads')
+    @app.cli.command()
+    def worker():
+        tooltool_api.cli.cmd_worker(app)
+
+    @app.cli.command()
+    def replicate():
+        tooltool_api.cli.cmd_replicate(app)
+
+    @app.cli.command()
+    def check_pending_uploads():
+        tooltool_api.cli.cmd_check_pending_uploads(app)
 
     return app

--- a/src/tooltool/api/tooltool_api/__init__.py
+++ b/src/tooltool/api/tooltool_api/__init__.py
@@ -3,10 +3,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import flask
 import os
-import werkzeug.exceptions
 import typing
+
+import flask
+import werkzeug.exceptions
 
 import backend_common
 import backend_common.api
@@ -48,16 +49,8 @@ def create_app(config: dict = None) -> flask.Flask:
     for code, exception in werkzeug.exceptions.default_exceptions.items():
         app.register_error_handler(exception, custom_handle_default_exceptions)
 
-    @app.cli.command()
-    def worker():
-        tooltool_api.cli.cmd_worker(app)
-
-    @app.cli.command()
-    def replicate():
-        tooltool_api.cli.cmd_replicate(app)
-
-    @app.cli.command()
-    def check_pending_uploads():
-        tooltool_api.cli.cmd_check_pending_uploads(app)
+    app.cli.add_command(tooltool_api.cli.cmd_worker, 'worker')
+    app.cli.add_command(tooltool_api.cli.cmd_replicate, 'replicate')
+    app.cli.add_command(tooltool_api.cli.cmd_check_pending_uploads, 'check_pending_uploads')
 
     return app


### PR DESCRIPTION

This reverts commit bf1f4e93bd3f54c23a4cebaf844dfa977339c0a4.

Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1524620