### PR TITLE
staticanalysis/bot - Add suport for Coverity Analysis reporting for C/C++ compilation units.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/__init__.py
@@ -16,6 +16,7 @@ CLANG_TIDY = 'clang-tidy'
 CLANG_FORMAT = 'clang-format'
 MOZLINT = 'mozlint'
 INFER = 'infer'
+COVERITY = 'coverity'
 
 
 class AnalysisException(Exception):
@@ -25,6 +26,27 @@ class AnalysisException(Exception):
     def __init__(self, code, message):
         self.code = code
         super().__init__(message)
+
+
+class DefaultAnalyzer(abc.ABC):
+    '''
+    Default base analzer that must be implemented by each analyzer in particular
+    '''
+    @abc.abstractmethod
+    def run(self, revision):
+        '''
+        The run procedure that each analyzer must implement, this is the entry
+        point where the execution of the checker starts
+        '''
+        raise NotImplementedError
+
+    def can_run_before_patch(self):
+        '''
+        By default an analyzer can be ran two times, before the patch is applied
+        and after. By there are special cases where this behaviour is not wanted,
+        hence it must be reflected in the re-implementation of this method.
+        '''
+        return True
 
 
 class Issue(abc.ABC):

--- a/src/staticanalysis/bot/static_analysis_bot/clang/format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/format.py
@@ -7,6 +7,7 @@ from parsepatch.patch import Patch
 
 from cli_common.log import get_logger
 from static_analysis_bot import CLANG_FORMAT
+from static_analysis_bot import DefaultAnalyzer
 from static_analysis_bot import Issue
 from static_analysis_bot import stats
 from static_analysis_bot.config import settings
@@ -23,7 +24,7 @@ ISSUE_MARKDOWN = '''
 '''
 
 
-class ClangFormat(object):
+class ClangFormat(DefaultAnalyzer):
     '''
     Clang Format direct Runner
     List potential issues on modified files

--- a/src/staticanalysis/bot/static_analysis_bot/clang/tidy.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/tidy.py
@@ -11,6 +11,7 @@ import subprocess
 from cli_common.log import get_logger
 from static_analysis_bot import CLANG_TIDY
 from static_analysis_bot import AnalysisException
+from static_analysis_bot import DefaultAnalyzer
 from static_analysis_bot import Issue
 from static_analysis_bot import stats
 from static_analysis_bot.config import CONFIG_URL
@@ -62,7 +63,7 @@ CLANG_SETUP_CMD = [
 ]
 
 
-class ClangTidy(object):
+class ClangTidy(DefaultAnalyzer):
     '''
     Clang Tidy Parallel runner
     Inspired by run-clang-tidy.py

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -76,11 +76,9 @@ def main(source,
     # Setup settings before stats
     settings.setup(
         secrets['APP_CHANNEL'],
-        cache_root,
-        secrets['PUBLICATION'],
+        cache_root, secrets['PUBLICATION'],
         secrets['ALLOWED_PATHS'],
-    )
-
+        secrets.get('COVERITY_CONFIG'))
     # Setup statistics
     datadog_api_key = secrets.get('DATADOG_API_KEY')
     if datadog_api_key:

--- a/src/staticanalysis/bot/static_analysis_bot/config.py
+++ b/src/staticanalysis/bot/static_analysis_bot/config.py
@@ -49,7 +49,19 @@ class Settings(object):
         self.repo_shared_dir = None
         self.taskcluster = None
 
-    def setup(self, app_channel, cache_root, publication, allowed_paths):
+        # For Coverity Analysis package info
+        self.cov_analysis_url = None
+        self.cov_package_name = None
+        self.cov_package_ver = None
+        self.cov_url = None
+        self.cov_auth = None
+
+    def setup(self,
+              app_channel,
+              cache_root,
+              publication,
+              allowed_paths,
+              cov_config=None):
         self.app_channel = app_channel
         self.download({
             'cpp_extensions': frozenset(['.c', '.h', '.cpp', '.cc', '.cxx', '.hh', '.hpp', '.hxx', '.m', '.mm']),
@@ -81,6 +93,14 @@ class Settings(object):
         assert isinstance(allowed_paths, list)
         assert all(map(lambda p: isinstance(p, str), allowed_paths))
         self.allowed_paths = allowed_paths
+
+        # Set different info for Coverity
+        if cov_config is not None:
+            self.cov_analysis_url = cov_config.get('package_url')
+            self.cov_package_name = cov_config.get('package_name')
+            self.cov_url = cov_config.get('server_url')
+            self.cov_auth = cov_config.get('auth_key')
+            self.cov_package_ver = cov_config.get('package_ver')
 
     def __getattr__(self, key):
         if key not in self.config:

--- a/src/staticanalysis/bot/static_analysis_bot/coverity/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/coverity/__init__.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import io
+import os
+import requests
+import tarfile
+import cli_common.log
+import cli_common.utils
+from static_analysis_bot.config import settings
+from static_analysis_bot import AnalysisException
+
+
+logger = cli_common.log.get_logger(__name__)
+
+COVERITY_CONFIG = '''
+  {
+    "type": "Coverity configuration",
+    "format_version": 1,
+    "settings": {
+      "server": {
+        "host": "%s",
+        "ssl" : true,
+        "on_new_cert" : "trust",
+        "auth_key_file": "%s"
+      },
+      "stream": "Firefox",
+      "cov_run_desktop": {
+        "build_cmd": [],
+        "clean_cmd": []
+      }
+    }
+  }
+'''
+
+
+def setup(index):
+    '''
+    Setup Taskcluster Coverity build for static-analysis
+    '''
+    assert settings.cov_url, 'Missing secret COVERITY_CONFIG:server_url'
+    assert settings.cov_analysis_url, 'Missing secret COVERITY_CONFIG:package_url'
+    assert settings.cov_auth, 'Missing secret COVERITY_CONFIG:auth_key'
+
+    target = os.path.join(
+        os.environ['MOZBUILD_STATE_PATH'], 'coverity')
+
+    # Generate the coverity.conf and auth files
+    cov_auth_path = os.path.join(target, 'auth')
+    cov_setup_path = os.path.join(target, 'coverity.conf')
+    cov_conf = COVERITY_CONFIG % (settings.cov_url, cov_auth_path)
+
+    logger.info('Downloading from {}.'.format(settings.cov_analysis_url))
+    cli_common.utils.retry(lambda: download(settings.cov_analysis_url, target))
+    if not os.path.exists(target):
+        raise AnalysisException('artifact', 'Setup failed for {}'.format(target))
+
+    with open(cov_auth_path, 'w') as f:
+        f.write(settings.cov_auth)
+
+    # Modify it's permission to 600
+    os.chmod(cov_auth_path, 0o600)
+
+    with open(cov_setup_path, 'a') as f:
+        f.write(cov_conf)
+
+
+def download(artifact_url, target):
+    # Download Taskcluster archive
+    resp = requests.get(artifact_url, verify=False, stream=True)
+    resp.raise_for_status()
+
+    # Extract archive into destination
+    with tarfile.open(fileobj=io.BytesIO(resp.content)) as tar:
+        tar.extractall(target)

--- a/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
@@ -1,0 +1,255 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import os
+import shutil
+import subprocess
+
+from cli_common.command import run_check
+from cli_common.log import get_logger
+from static_analysis_bot import COVERITY
+from static_analysis_bot import AnalysisException
+from static_analysis_bot import DefaultAnalyzer
+from static_analysis_bot import Issue
+from static_analysis_bot import stats
+from static_analysis_bot.config import settings
+from static_analysis_bot.revisions import Revision
+
+logger = get_logger(__name__)
+
+ISSUE_MARKDOWN = '''
+## coverity error
+
+- **Message**: {message}
+- **Location**: {location}
+- **In patch**: {in_patch}
+- **Coverity check**: {check}
+- **Publishable **: {publishable}
+- **Is new**: {is_new}
+
+```
+{body}
+```
+'''
+
+
+class Coverity(DefaultAnalyzer):
+    '''
+    Coverity runner
+    '''
+    def __init__(self, validate_checks=True):
+        # Ensure that we have all what we need into settings
+        assert settings.cov_package_name, 'Missing secret COVERITY_CONFIG:package_name'
+        assert settings.cov_package_ver, 'Missing secret COVERITY_CONFIG:package_ver'
+
+        self.cov_state_path = os.path.join(os.environ['MOZBUILD_STATE_PATH'],
+                                           'coverity')
+        self.cov_path = os.path.join(self.cov_state_path,
+                                     settings.cov_package_name)
+        self.cov_run_desktop = os.path.join(self.cov_path, 'bin', 'cov-run-desktop')
+        self.cov_translate = os.path.join(self.cov_path, 'bin', 'cov-translate')
+        self.cov_configure = os.path.join(self.cov_path, 'bin', 'cov-configure')
+        self.cov_work_path = os.path.join(self.cov_state_path, 'data-coverity')
+        self.cov_idir_path = os.path.join(self.cov_work_path, settings.cov_package_ver, 'idir')
+
+        assert os.path.exists(self.cov_path), \
+            'Missing Coverity in {}'.format(self.cov_path)
+
+    def get_files_with_commands(self):
+        '''
+        Returns an array of dictionaries having file_path with build command
+        '''
+
+        compile_db = json.load(open(self.compile_commands_path, 'r'))
+
+        commands_list = []
+
+        for rev_file in self.revision.files:
+            # It must be a C/C++ file
+            _, ext = os.path.splitext(rev_file)
+
+            if ext.lower() not in settings.cpp_extensions:
+                continue
+            file_with_abspath = os.path.join(settings.repo_dir, rev_file)
+            for f in compile_db:
+                # Found for a file that we are looking
+                if file_with_abspath == f['file']:
+                    commands_list.append(f)
+
+        return commands_list
+
+    @stats.api.timed('runtime.coverity')
+    def run(self, revision):
+        '''
+        Run coverity
+        '''
+        assert isinstance(revision, Revision)
+        self.revision = revision
+
+        # Based on our previous configs we should already have generated compile_commands.json
+        self.compile_commands_path = os.path.join(settings.repo_dir, 'obj-x86_64-pc-linux-gnu', 'compile_commands.json')
+
+        assert os.path.exists(self.compile_commands_path), \
+            'Missing Coverity in {}'.format(self.compile_commands_path)
+
+        logger.info('Building command files from compile_commands.json')
+
+        # Retrieve the revision files with build commands associated
+        commands_list = self.get_files_with_commands()
+        assert commands_list is not [], 'Commands List is empty'
+        logger.info('Built commands for {} files'.format(len(commands_list)))
+
+        cmd = ['gecko-env', self.cov_run_desktop, '--setup']
+        logger.info('Running Coverity Setup', cmd=cmd)
+        try:
+            run_check(cmd, cwd=self.cov_path)
+        except subprocess.CalledProcessError as e:
+            raise AnalysisException('coverity', 'Coverity Setup failed: {}'.format(e.output))
+
+        cmd = ['gecko-env', self.cov_configure, '--clang']
+        logger.info('Running Coverity Configure', cmd=cmd)
+        try:
+            run_check(cmd, cwd=self.cov_path)
+        except subprocess.CalledProcessError as e:
+            raise AnalysisException('coverity', 'Coverity Configure failed: {}'.format(e.output))
+
+        # For each element in commands_list run `cov-translate`
+        for element in commands_list:
+            cmd = [
+                'gecko-env', self.cov_translate, '--dir', self.cov_idir_path,
+                element['command']
+            ]
+            logger.info('Running Coverity Tranlate', cmd=cmd)
+            try:
+                run_check(cmd, cwd=element['directory'])
+            except subprocess.CalledProcessError as e:
+                raise AnalysisException('coverity', 'Coverity Translate failed: {}'.format(e.output))
+
+        # Once the capture is performed we need to do the actual Coverity Desktop analysis
+        cmd = [
+            'gecko-env', self.cov_run_desktop, '--json-output-v6',
+            'cov-results.json', '--strip-path', settings.repo_dir
+        ]
+        cmd += [element['file'] for element in commands_list]
+        logger.info('Running Coverity Analysis', cmd=cmd)
+        try:
+            run_check(cmd, cwd=self.cov_state_path)
+        except subprocess.CalledProcessError as e:
+            raise AnalysisException('coverity', 'Coverity Analysis failed: {}'.format(e.output))
+
+        # Write the results.json to the artifact directory to have it later on for debug
+        coverity_results_path = os.path.join(self.cov_state_path, 'cov-results.json')
+        coverity_results_path_on_tc = os.path.join(settings.taskcluster.results_dir, 'cov-results.json')
+
+        shutil.copyfile(coverity_results_path, coverity_results_path_on_tc)
+
+        # Parsing the issues from coverity_results_path
+        logger.info('Parsing Coverity issues')
+        return self.return_issues(coverity_results_path, revision)
+
+    def return_issues(self, coverity_results_path, revision):
+        '''
+        Parse Coverity json into structured issues
+        '''
+        if not os.path.isfile(coverity_results_path):
+            raise AnalysisException(
+                'coverity',
+                'Coverity Analysis did not generate an analysis report.')
+
+        with open(coverity_results_path) as f:
+            result = json.load(f)
+
+            if 'issues' not in result:
+                logger.info('Coverity did not find any issues')
+                return []
+
+            return [CoverityIssue(issue, revision) for issue in result['issues']]
+
+    def can_run_before_patch(self):
+        '''
+        Coverity should run only once, after the patch is applied.
+        '''
+        return False
+
+
+class CoverityIssue(Issue):
+    '''
+    An issue reported by coverity
+    '''
+    ANALYZER = COVERITY
+
+    def __init__(self, issue, revision):
+        assert not settings.repo_dir.endswith('/')
+        self.revision = revision
+        # We look only for the last event
+        event_path = issue['events'][-1]
+        checker_properties = issue['checkerProperties']
+        # Strip the leading slash
+        self.path = issue['strippedMainEventFilePathname'].strip('/')
+        self.line = issue['mainEventLineNumber']
+        self.bug_type = checker_properties['category']
+        self.kind = issue['checkerName']
+        self.message = event_path['eventDescription']
+        self.body = None
+        self.nb_lines = 1
+
+    def __str__(self):
+        return '[{}] {} {}'.format(self.kind, self.path, self.line)
+
+    def build_extra_identifiers(self):
+        '''
+        Used to compare with same-class issues
+        '''
+        return {
+            'bug_type': self.bug_type,
+            'kind': self.kind,
+            'line': self.line,
+        }
+
+    def is_problem(self):
+        return True
+
+    def validates(self):
+        '''
+        Publish Coverity issues all the time
+        '''
+        return True
+
+    def as_text(self):
+        '''
+        Build the text body published on reporters
+        '''
+        return self.message
+
+    def as_markdown(self):
+        return ISSUE_MARKDOWN.format(
+            check=self.kind,
+            message=self.message,
+            location='{}:{}'.format(self.path, self.line),
+            body=self.body,
+            in_patch='yes',
+            publishable='yes',
+            is_new='yes'
+        )
+
+    def as_dict(self):
+        '''
+        Outputs all available information into a serializable dict
+        '''
+        return {
+            'analyzer': 'Coverity',
+            'path': self.path,
+            'line': self.line,
+            'nb_lines': self.nb_lines,
+            'bug_type': self.bug_type,
+            'kind': self.kind,
+            'message': self.message,
+            'body': self.body,
+            'in_patch': self.revision.contains(self),
+            'is_new': self.is_new,
+            'validates': self.validates(),
+            'publishable': True,
+        }

--- a/src/staticanalysis/bot/static_analysis_bot/infer/infer.py
+++ b/src/staticanalysis/bot/static_analysis_bot/infer/infer.py
@@ -11,6 +11,7 @@ from cli_common.command import run_check
 from cli_common.log import get_logger
 from static_analysis_bot import INFER
 from static_analysis_bot import AnalysisException
+from static_analysis_bot import DefaultAnalyzer
 from static_analysis_bot import Issue
 from static_analysis_bot import stats
 from static_analysis_bot.config import settings
@@ -41,7 +42,7 @@ INFER_SETUP_CMD = [
 ]
 
 
-class Infer(object):
+class Infer(DefaultAnalyzer):
     '''
     Infer runner
     '''

--- a/src/staticanalysis/bot/static_analysis_bot/lint.py
+++ b/src/staticanalysis/bot/static_analysis_bot/lint.py
@@ -7,6 +7,7 @@ from cli_common.command import run
 from cli_common.log import get_logger
 from static_analysis_bot import MOZLINT
 from static_analysis_bot import AnalysisException
+from static_analysis_bot import DefaultAnalyzer
 from static_analysis_bot import Issue
 from static_analysis_bot import stats
 from static_analysis_bot.config import settings
@@ -145,7 +146,7 @@ class MozLintIssue(Issue):
         }
 
 
-class MozLint(object):
+class MozLint(DefaultAnalyzer):
     '''
     Exposes mach lint capabilities
     '''

--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -7,6 +7,7 @@ import itertools
 
 from static_analysis_bot.clang.format import ClangFormatIssue
 from static_analysis_bot.clang.tidy import ClangTidyIssue
+from static_analysis_bot.coverity.coverity import CoverityIssue
 from static_analysis_bot.infer.infer import InferIssue
 from static_analysis_bot.lint import MozLintIssue
 
@@ -18,6 +19,10 @@ COMMENT_PARTS = {
     InferIssue: {
         'defect': ' - {nb} found by infer',
         'analyzer': ' - `./mach static-analysis check-java path/to/file.java` (Java)',
+    },
+    CoverityIssue: {
+        'defect': ' - {nb} found by Coverity',
+        'analyzer': ' - Coverity Scan Analysis cannot be ran locally.',
     },
     ClangFormatIssue: {
         'defect': ' - {nb} found by clang-format',

--- a/src/staticanalysis/bot/tests/conftest.py
+++ b/src/staticanalysis/bot/tests/conftest.py
@@ -411,3 +411,33 @@ def mock_infer_repeats(mock_config):
     path = os.path.join(MOCK_DIR, 'infer-repeats.txt')
     with open(path) as f:
         return f.read().replace('{REPO}', mock_config.repo_dir)
+
+
+@pytest.fixture
+def mock_coverity(tmpdir):
+    '''
+    Mocks the coverity environment
+    '''
+    from static_analysis_bot.config import settings
+    settings.cov_package_name = 'coverity'
+    settings.cov_package_ver = '1'
+
+    # Build the mock directory
+    os.environ['MOZBUILD_STATE_PATH'] = str(tmpdir.realpath())
+    tmpdir.mkdir('coverity').mkdir(settings.cov_package_name)
+
+
+@pytest.fixture
+def mock_coverity_empty_output():
+    '''
+    Mocks an empty result file for coverity
+    '''
+    return os.path.join(MOCK_DIR, 'coverity-empty.json')
+
+
+@pytest.fixture
+def mock_coverity_output():
+    '''
+    Load a real case clang output
+    '''
+    return os.path.join(MOCK_DIR, 'coverity.json')

--- a/src/staticanalysis/bot/tests/mocks/coverity-empty.json
+++ b/src/staticanalysis/bot/tests/mocks/coverity-empty.json
@@ -1,0 +1,3 @@
+{
+  "type" : "Coverity issues"
+}

--- a/src/staticanalysis/bot/tests/mocks/coverity.json
+++ b/src/staticanalysis/bot/tests/mocks/coverity.json
@@ -1,0 +1,19 @@
+{
+  "type" : "Coverity issues",
+  "issues" : [
+    {
+      "checkerName" : "Dummy Checker Name",
+      "mainEventFilePathname" : "/path/to/test.cpp",
+      "strippedMainEventFilePathname" : "/to/test.cpp",
+      "mainEventLineNumber" : 123,
+      "events" : [
+        {
+          "eventDescription" : "Some dummy event"
+        }
+      ],
+      "checkerProperties" : {
+        "category" : "Dummy Category"
+      }
+    }
+  ]
+}

--- a/src/staticanalysis/bot/tests/test_coverity.py
+++ b/src/staticanalysis/bot/tests/test_coverity.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+
+def test_infer_parser(mock_config, mock_repository, mock_revision, mock_coverity, mock_coverity_empty_output, mock_coverity_output):
+    '''
+    Test the infer (or mach static-analysis) parser
+    '''
+    from static_analysis_bot.coverity.coverity import Coverity
+    cov = Coverity()
+
+    # Expected empty result
+    issues = cov.return_issues(mock_coverity_empty_output, mock_revision)
+    assert issues == []
+
+    # Real issues
+    issues = cov.return_issues(mock_coverity_output, mock_revision)
+
+    # The list must have one element
+    assert len(issues) == 1
+
+    # Verify that each element has a sane value
+    issue = issues[0]
+    assert issue.path == 'to/test.cpp'
+    assert issue.line == 123
+    assert issue.bug_type == 'Dummy Category'
+    assert issue.message == 'Some dummy event'
+
+    # Testing it as_text
+    assert issue.as_text() == 'Some dummy event'
+
+    # Testing as_markdown
+    issue.body = 'Dummy body'
+    assert issue.as_markdown() == '''
+## coverity error
+
+- **Message**: Some dummy event
+- **Location**: to/test.cpp:123
+- **In patch**: yes
+- **Coverity check**: Dummy Checker Name
+- **Publishable **: yes
+- **Is new**: yes
+
+```
+Dummy body
+```
+'''


### PR DESCRIPTION
1. It uses the clang infrastructure in order to build the compilation commands that are fed
to the cov translation units for each compilation unit that is part of the analysed diff.
Once the translation has been completed, we forward the translated content to the analysis
machine provided by coverity desktop wrapper.
Once the analysis is performed the results are forwarded to the coverity platform server,
that sends back only the defects that are sane to the patch that was analysed.
2. Migrate the analyzers from Object inhertiance to DefaultAnalyzer.
This permits a better underlying abstractization of the generic interface for the
analyzer.