### PR TITLE
Add to .gitignore .vscode and all of it's subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.cache
 /.elm
 /.floo
+/.vscode/**
 /Dockerfile
 /TODOs.org
 /docs/build/


### PR DESCRIPTION
For whom is working with VSCode as an ide this is a good addition in order to
streamline to working process when VScode begins to creates it's config files
for the current working-space.