### PR TITLE
staticanalysis/bot: User artifact downloader for our resources.

### DIFF
--- a/src/staticanalysis/bot/default.nix
+++ b/src/staticanalysis/bot/default.nix
@@ -51,7 +51,6 @@ let
           env = {
             "SSL_CERT_FILE" = "${cacert}/etc/ssl/certs/ca-bundle.crt";
             "APP_CHANNEL" = branch;
-            "MOZ_AUTOMATION" = "1";
           };
         };
 
@@ -150,8 +149,6 @@ let
     shellHook = ''
       export PATH="${mercurial}/bin:${git}/bin:${python27}/bin:${python36}/bin:${nodejs}/bin:$PATH"
 
-      # Setup mach automation
-      export MOZ_AUTOMATION=1
 
       # Use clang mozconfig from gecko-env
       export MOZCONFIG=${gecko-env}/conf/mozconfig
@@ -178,7 +175,6 @@ let
         "MOZCONFIG=${gecko-env}/conf/mozconfig"
         "CODESPELL=${python.packages.codespell}/bin/codespell"
         "SHELLCHECK=${shellcheck}/bin/shellcheck"
-        "MOZ_AUTOMATION=1"
         "MOZBUILD_STATE_PATH=/tmp/mozilla-state"
         "_JAVA_OPTIONS=-Duser.home=/tmp/mozilla-state"
         "SHELL=xterm"

--- a/src/staticanalysis/bot/static_analysis_bot/clang/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/__init__.py
@@ -8,7 +8,13 @@ import requests
 import io
 import os
 import cli_common.utils
+from cli_common.command import run_check
+from cli_common.log import get_logger
 from static_analysis_bot import AnalysisException
+from static_analysis_bot.config import settings
+
+
+logger = get_logger(__name__)
 
 
 def setup(
@@ -18,30 +24,35 @@ def setup(
     artifact='public/build/clang-tidy.tar.xz',
     repository='autoland',
 ):
-    '''
-    Setup Taskcluster clang build for static-analysis
-    Defaults values are from https://dxr.mozilla.org/mozilla-central/source/taskcluster/ci/toolchain/linux.yml
-    - Download the artifact from latest Taskcluster build
-    - Extracts it into the MOZBUILD_STATE_PATH as expected by mach
-    '''
-    namespace = 'gecko.v2.{}.{}.{}.{}'.format(repository, revision, product, job_name)
-    artifact_url = 'https://index.taskcluster.net/v1/task/{}/artifacts/{}'.format(namespace, artifact)
+    try:
+        run_check(['gecko-env', './mach', 'artifact', 'toolchain',
+                   '--from-build', 'linux64-clang-tidy'], cwd=settings.repo_dir)
+    except Exception as ex:
+        logger.warn('Artifact downloader for clang-tidy using mach failed with: {}'.format(str(ex)))
+        '''
+        In case artifact downloader failed when using 'mach' we try to do the setup manually.
+        Defaults values are from https://dxr.mozilla.org/mozilla-central/source/taskcluster/ci/toolchain/linux.yml
+        - Download the artifact from latest Taskcluster build
+        - Extracts it into the MOZBUILD_STATE_PATH as expected by mach
+        '''
+        namespace = 'gecko.v2.{}.{}.{}.{}'.format(repository, revision, product, job_name)
+        artifact_url = 'https://index.taskcluster.net/v1/task/{}/artifacts/{}'.format(namespace, artifact)
 
-    # Mach expects clang binaries in this specific root dir
-    target = os.path.join(
-        os.environ['MOZBUILD_STATE_PATH'],
-        'clang-tools',
-    )
+        # Mach expects clang binaries in this specific root dir
+        target = os.path.join(
+            os.environ['MOZBUILD_STATE_PATH'],
+            'clang-tools',
+        )
 
-    def _download():
-        # Download Taskcluster archive
-        resp = requests.get(artifact_url, stream=True)
-        if not resp.ok:
-            raise AnalysisException('artifact', 'Download failed {}'.format(artifact_url))
+        def _download():
+            # Download Taskcluster archive
+            resp = requests.get(artifact_url, stream=True)
+            if not resp.ok:
+                raise AnalysisException('artifact', 'Download failed {}'.format(artifact_url))
 
-        # Extract archive into destination
-        with tarfile.open(fileobj=io.BytesIO(resp.content)) as tar:
-            tar.extractall(target)
+            # Extract archive into destination
+            with tarfile.open(fileobj=io.BytesIO(resp.content)) as tar:
+                tar.extractall(target)
 
-    # Retry several times the download process
-    cli_common.utils.retry(_download)
+        # Retry several times the download process
+        cli_common.utils.retry(_download)


### PR DESCRIPTION
This patch implements the possibility of downloading our resources using
the artifact downloader implemented in ```mach```, if this fails we use as
a backup the old direct-link method.