### PR TITLE
staticanalysis/bot: For Coverity Analysis do not use the last event from the stack but use the main event marked accordingly.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
@@ -184,8 +184,14 @@ class CoverityIssue(Issue):
     def __init__(self, issue, revision):
         assert not settings.repo_dir.endswith('/')
         self.revision = revision
-        # We look only for the last event
-        event_path = issue['events'][-1]
+        # We look only for main event
+        event_path = next((event for event in issue['events'] if event['main'] is True), None)
+
+        if event_path is None:
+            raise AnalysisException(
+                'coverity',
+                'Coverity Analysis did not find main event for mergeKey {}'.format(issue['mergeKey']))
+
         checker_properties = issue['checkerProperties']
         # Strip the leading slash
         self.path = issue['strippedMainEventFilePathname'].strip('/')

--- a/src/staticanalysis/bot/tests/mocks/coverity.json
+++ b/src/staticanalysis/bot/tests/mocks/coverity.json
@@ -8,7 +8,8 @@
       "mainEventLineNumber" : 123,
       "events" : [
         {
-          "eventDescription" : "Some dummy event"
+          "eventDescription" : "Some dummy event",
+          "main" : true
         }
       ],
       "checkerProperties" : {


### PR DESCRIPTION
After more testing I've realized that's better to stop taking into consideration the last event from the stack that can be misleading.