### PR TITLE
staticanalysis/bot: Add option to print the full stack of the defect for Coverity analysis

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/config.py
+++ b/src/staticanalysis/bot/static_analysis_bot/config.py
@@ -55,6 +55,7 @@ class Settings(object):
         self.cov_package_ver = None
         self.cov_url = None
         self.cov_auth = None
+        self.cov_full_stack = False
 
     def setup(self,
               app_channel,
@@ -101,6 +102,7 @@ class Settings(object):
             self.cov_url = cov_config.get('server_url')
             self.cov_auth = cov_config.get('auth_key')
             self.cov_package_ver = cov_config.get('package_ver')
+            self.cov_full_stack = cov_config.get('full_stack', False)
 
     def __getattr__(self, key):
         if key not in self.config:

--- a/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
@@ -35,6 +35,15 @@ ISSUE_MARKDOWN = '''
 ```
 '''
 
+ISSUE_ELEMENT_IN_STACK = '''
+- //{file_path}:{line_number}//:
+-- `{path_type}: {description}`.
+'''
+
+ISSUE_RELATION = '''
+The path that leads to this defect is:
+'''
+
 
 class Coverity(DefaultAnalyzer):
     '''
@@ -201,6 +210,16 @@ class CoverityIssue(Issue):
         self.message = event_path['eventDescription']
         self.body = None
         self.nb_lines = 1
+
+        if settings.cov_full_stack:
+            self.message += ISSUE_RELATION
+            # Embed all events into message
+            for event in issue['events']:
+                self.message += ISSUE_ELEMENT_IN_STACK.format(
+                    file_path=event['strippedFilePathname'],
+                    line_number=event['lineNumber'],
+                    path_type=event['eventTag'],
+                    description=event['eventDescription'])
 
     def __str__(self):
         return '[{}] {} {}'.format(self.kind, self.path, self.line)


### PR DESCRIPTION
Unfortunately the markdown language that is sported by Phabricator is pretty limited so we cannot use fancy syntax in order to have something that is very candy eye.
I've specially made a separate case for as_text for Coveirty Analyzer since I didn't want to change the output of as_markdown that is used to send email hence keeping the consistency of the format of the mails is very important and you don't need that much of the context because you can download the cov_results.json form the job.