### PR TITLE
codecoverage/bot: Use taskcluster-client library instead of manually implementing API calls

### DIFF
--- a/src/codecoverage/bot/code_coverage_bot/taskcluster.py
+++ b/src/codecoverage/bot/code_coverage_bot/taskcluster.py
@@ -6,8 +6,8 @@ from zipfile import is_zipfile
 
 import requests
 
-from cli_common.utils import retry
 from cli_common.taskcluster import get_service
+from cli_common.utils import retry
 
 index_base = 'https://index.taskcluster.net/v1/'
 queue_base = 'https://queue.taskcluster.net/v1/'
@@ -47,13 +47,11 @@ def get_task(branch, revision, platform):
 
 
 def get_task_details(task_id):
-    task_details_json = queue_service.task(task_id)
-    return task_details_json
+    return queue_service.task(task_id)
 
 
 def get_task_status(task_id):
-    task_status_json = queue_service.task(task_id)
-    return task_status_json
+    return queue_service.status(task_id)
 
 
 def get_task_artifacts(task_id):
@@ -63,10 +61,10 @@ def get_task_artifacts(task_id):
 
 
 def get_tasks_in_group(group_id):
-    reply = queue_service.listTaskGroup(group_id,{'limit': 200})
+    reply = queue_service.listTaskGroup(group_id, {'limit': 200})
     tasks = reply['tasks']
     while 'continuationToken' in reply:
-        reply = queue_service.listTaskGroup(group_id,{
+        reply = queue_service.listTaskGroup(group_id, {
             'limit': 200,
             'continuationToken': reply['continuationToken']
         })


### PR DESCRIPTION
Modified the functions `get_task_details`, `get_task_status`, `get_tasks_in_group` to use the taskcluster API
Fixes #934 