### PR TITLE
staticanalysis/bot: If there are no compilation units abort the Coverity Analysis.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
@@ -111,6 +111,10 @@ class Coverity(DefaultAnalyzer):
         assert commands_list is not [], 'Commands List is empty'
         logger.info('Built commands for {} files'.format(len(commands_list)))
 
+        if len(commands_list) == 0:
+            logger.info('Coverity didn\'t find any compilation units to use.')
+            return []
+
         cmd = ['gecko-env', self.cov_run_desktop, '--setup']
         logger.info('Running Coverity Setup', cmd=cmd)
         try:


### PR DESCRIPTION
We need compilation units in order to be able to run Coverity. This fix is because of this [issue](https://tools.taskcluster.net/groups/FigmseTSR-KFM-VG5Q6vBA/tasks/FigmseTSR-KFM-VG5Q6vBA/runs/0/logs/public%2Flogs%2Flive.log).