### PR TITLE
staticanalysis/bot: Use actual number of lines in the file to identify full file issues

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/coverage.py
+++ b/src/staticanalysis/bot/static_analysis_bot/coverage.py
@@ -30,17 +30,21 @@ class CoverageIssue(Issue):
     ANALYZER = COVERAGE
 
     def __init__(self, path, lineno, message, revision):
-        self.nb_lines = -1
-        self.line = lineno and int(lineno) or 0
-        self.message = message
-        self.revision = revision
-
         # Ensure path is always relative to the repository
         self.path = path
         if self.path.startswith(settings.repo_dir):
             self.path = os.path.relpath(self.path, settings.repo_dir)
-        assert os.path.exists(os.path.join(settings.repo_dir, self.path)), \
+
+        full_path = os.path.join(settings.repo_dir, self.path)
+
+        assert os.path.exists(full_path), \
             'Missing {} in repo {}'.format(self.path, settings.repo_dir)
+
+        self.line = lineno and int(lineno) or 0
+        with open(full_path) as f:
+            self.nb_lines = sum(1 for line in f)
+        self.message = message
+        self.revision = revision
 
     def __str__(self):
         return self.path

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -113,10 +113,6 @@ class Revision(object):
             logger.warn('Issue path in not in revision', path=issue.path, revision=self)
             return False
 
-        # If nb_lines is -1, it means the issue applies to the entire file.
-        if issue.nb_lines == -1:
-            return True
-
         # Detect if this issue is in the patch
         lines = set(range(issue.line, issue.line + issue.nb_lines))
         return not lines.isdisjoint(modified_lines)

--- a/src/staticanalysis/bot/tests/test_coverage.py
+++ b/src/staticanalysis/bot/tests/test_coverage.py
@@ -21,14 +21,14 @@ def test_coverage(mock_config, mock_repository, mock_revision, mock_coverage):
 
     # Build fake lines.
     for path in mock_revision.files:
-        mock_revision.lines[path] = [1]
+        mock_revision.lines[path] = [0]
 
     # Build fake files.
-    for path in mock_revision.files:
+    for i, path in enumerate(mock_revision.files):
         full_path = os.path.join(mock_config.repo_dir, path)
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
         with open(full_path, 'w') as f:
-            f.write('line')
+            f.write('line\n' * (i + 1))
 
     issues = cov.run(mock_revision)
 
@@ -42,6 +42,8 @@ def test_coverage(mock_config, mock_repository, mock_revision, mock_coverage):
     assert issue.message == 'This file is uncovered'
     assert str(issue) == 'my/path/file1.cpp'
 
+    assert issue.build_lines_hash() == 'c73b73af8851e9e91bc6b4dc12e7dace0a2bfb931c1d0b8b36ef367319f58cd1'
+
     assert not issue.is_third_party()
     assert issue.validates()
 
@@ -49,7 +51,7 @@ def test_coverage(mock_config, mock_repository, mock_revision, mock_coverage):
         'analyzer': 'coverage',
         'path': 'my/path/file1.cpp',
         'line': 0,
-        'nb_lines': -1,
+        'nb_lines': 1,
         'message': 'This file is uncovered',
         'is_third_party': False,
         'in_patch': True,
@@ -77,6 +79,8 @@ This file is uncovered
     assert issue.message == 'This file is uncovered'
     assert str(issue) == 'test/dummy/thirdparty.c'
 
+    assert issue.build_lines_hash() == '0b3ed69ca643edb6acc6fb43a1b9a235d7e773d43818396d4e05ead684e8f7c9'
+
     assert issue.is_third_party()
     assert issue.validates()
 
@@ -84,7 +88,7 @@ This file is uncovered
         'analyzer': 'coverage',
         'path': 'test/dummy/thirdparty.c',
         'line': 0,
-        'nb_lines': -1,
+        'nb_lines': 3,
         'message': 'This file is uncovered',
         'is_third_party': True,
         'in_patch': True,


### PR DESCRIPTION
This way we can:
1) Calculate the issue hash (otherwise we fail when calculating it);
2) Remove the hack of considering a nb_lines == -1 as a full-file issue.