### PR TITLE
staticanalysis/bot: Use validation protocol for Coverity issues

### DIFF
--- a/src/staticanalysis/bot/tests/conftest.py
+++ b/src/staticanalysis/bot/tests/conftest.py
@@ -428,23 +428,6 @@ def mock_coverity(tmpdir):
 
 
 @pytest.fixture
-def mock_coverity_empty_output():
-    '''
-    Mocks an empty result file for coverity
-    '''
-    return os.path.join(MOCK_DIR, 'coverity-empty.json')
-
-
-@pytest.fixture
-def mock_coverity_output():
-    '''
-    Load a real case clang output
-    '''
-    return os.path.join(MOCK_DIR, 'coverity.json')
-
-
-@responses.activate
-@pytest.fixture
 def mock_coverage():
     path = os.path.join(MOCK_DIR, 'zero_coverage_report.json')
     assert os.path.exists(path)

--- a/src/staticanalysis/bot/tests/mocks/coverity-silent.json
+++ b/src/staticanalysis/bot/tests/mocks/coverity-silent.json
@@ -1,0 +1,24 @@
+{
+  "type" : "Coverity issues",
+  "issues" : [
+    {
+      "checkerName" : "Dummy Checker Name",
+      "mainEventFilePathname" : "/path/to/test.cpp",
+      "strippedMainEventFilePathname" : "/to/test.cpp",
+      "mainEventLineNumber" : 123,
+      "events" : [
+        {
+          "eventDescription" : "Some dummy event",
+          "main" : true
+        }
+      ],
+      "stateOnServer" : {
+          "presentInReferenceSnapshot" : true,
+          "someOtherArg": true
+      },
+      "checkerProperties" : {
+        "category" : "Dummy Category"
+      }
+    }
+  ]
+}

--- a/src/staticanalysis/bot/tests/test_coverity.py
+++ b/src/staticanalysis/bot/tests/test_coverity.py
@@ -25,6 +25,10 @@ def test_coverity(mock_config, mock_repository, mock_revision, mock_coverity, mo
     assert issue.bug_type == 'Dummy Category'
     assert issue.message == 'Some dummy event'
 
+    # Assert it's local, hence publishable
+    assert issue.is_local()
+    assert issue.validates()
+
     # Testing it as_text
     assert issue.as_text() == 'Some dummy event'
 

--- a/src/staticanalysis/bot/tests/test_coverity.py
+++ b/src/staticanalysis/bot/tests/test_coverity.py
@@ -1,19 +1,29 @@
 # -*- coding: utf-8 -*-
+import os
+
+from conftest import MOCK_DIR
 
 
-def test_coverity(mock_config, mock_repository, mock_revision, mock_coverity, mock_coverity_empty_output, mock_coverity_output):
+def test_coverity_empty(mock_config, mock_repository, mock_revision, mock_coverity):
     '''
-    Test coverity
+    Test coverity empty output
     '''
     from static_analysis_bot.coverity.coverity import Coverity
     cov = Coverity()
 
-    # Expected empty result
-    issues = cov.return_issues(mock_coverity_empty_output, mock_revision)
+    issues = cov.return_issues(os.path.join(MOCK_DIR, 'coverity-empty.json'), mock_revision)
     assert issues == []
 
+
+def test_coverity_publishable(mock_config, mock_repository, mock_revision, mock_coverity):
+    '''
+    Test coverity complete issue & publishable
+    '''
+    from static_analysis_bot.coverity.coverity import Coverity
+    cov = Coverity()
+
     # Real issues
-    issues = cov.return_issues(mock_coverity_output, mock_revision)
+    issues = cov.return_issues(os.path.join(MOCK_DIR, 'coverity.json'), mock_revision)
 
     # The list must have one element
     assert len(issues) == 1
@@ -48,3 +58,28 @@ def test_coverity(mock_config, mock_repository, mock_revision, mock_coverity, mo
 Dummy body
 ```
 '''
+
+
+def test_coverity_silent(mock_config, mock_repository, mock_revision, mock_coverity):
+    '''
+    Test coverity silent issue
+    '''
+    from static_analysis_bot.coverity.coverity import Coverity
+    cov = Coverity()
+
+    # Real issues
+    issues = cov.return_issues(os.path.join(MOCK_DIR, 'coverity-silent.json'), mock_revision)
+
+    # The list must have one element
+    assert len(issues) == 1
+
+    # Verify that each element has a sane value
+    issue = issues[0]
+    assert issue.path == 'to/test.cpp'
+    assert issue.line == 123
+    assert issue.bug_type == 'Dummy Category'
+    assert issue.message == 'Some dummy event'
+
+    # Assert it's not local, hence does NOT validate
+    assert not issue.is_local()
+    assert not issue.validates()


### PR DESCRIPTION
The code review bot has a protocol to filter issues for publication: only issues that `validates()` will be processed for publication on Phabricator.

By loading all issues from the analyzer, we can still display them in the static analysis frontend, and only publish the relevant ones.