### PR TITLE
 staticanalysis/bot: For CoverityIssue override `is_publishable` and publish only if it's a local issue.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
@@ -249,6 +249,16 @@ class CoverityIssue(Issue):
             'line': self.line,
         }
 
+    def is_publishable(self):
+        '''
+        We don't use the default `is_publishable` implementation from `Issue`
+        because for CoverityIssue we don't apply the same logic to filter issues
+        as we do with the rest of our Analyzers, for IN_PATCH or BEFORE_AFTER methods,
+        since Coverity performs most of the checks on the servers and provides us a
+        snapshot with the checks that can be filtered only by the is_local function.
+        '''
+        return self.is_local()
+
     def is_local(self):
         '''
         The given coverity issue should be only locally stored and not in the


### PR DESCRIPTION
This patch is mainly a consequence of [this behaviour](https://tools.taskcluster.net/groups/BAi__NnFQIGMyEFrSCtZKA/tasks/BAi__NnFQIGMyEFrSCtZKA/runs/0/artifacts) that was seen present using the ```IN_PATCH``` analysis method.