### PR TITLE
Nicer report page to debug static analysis reports

### DIFF
--- a/src/staticanalysis/frontend/src/Choice.vue
+++ b/src/staticanalysis/frontend/src/Choice.vue
@@ -3,7 +3,7 @@
     <div class="dropdown-trigger">
       <button class="button" aria-haspopup="true" aria-controls="dropdown-menu">
         <span v-if="current === null">{{ default_choice_name }}</span>
-        <span v-else>{{ current.name }}</span>
+        <span v-else>{{ current|name }}</span>
       </button>
     </div>
     <div class="dropdown-menu" id="dropdown-menu" role="menu">
@@ -13,7 +13,7 @@
         </a>
         <hr class="dropdown-divider">
         <a href="#" class="dropdown-item" v-for="choice in choices" v-on:click="select(choice)" :class="{'is-active': current === choice }">
-          {{ choice.name }}
+          {{ choice|name }}
         </a>
       </div>
     </div>
@@ -40,6 +40,11 @@ export default {
   computed: {
     default_choice_name: function () {
       return 'All ' + this.name + 's'
+    }
+  },
+  filters: {
+    name: function (choice) {
+      return typeof choice === 'string' ? choice : choice.name
     }
   }
 }

--- a/src/staticanalysis/frontend/src/Choice.vue
+++ b/src/staticanalysis/frontend/src/Choice.vue
@@ -8,11 +8,11 @@
     </div>
     <div class="dropdown-menu" id="dropdown-menu" role="menu">
       <div class="dropdown-content">
-        <a href="#" class="dropdown-item" v-on:click="select(null)" :class="{'is-active': current === null }">
+        <a class="dropdown-item" v-on:click="select(null, $event)" :class="{'is-active': current === null }">
           {{ default_choice_name }}
         </a>
         <hr class="dropdown-divider">
-        <a href="#" class="dropdown-item" v-for="choice in choices" v-on:click="select(choice)" :class="{'is-active': current === choice }">
+        <a class="dropdown-item" v-for="choice in choices" v-on:click="select(choice, $event)" :class="{'is-active': current === choice }">
           {{ choice|name }}
         </a>
       </div>
@@ -31,10 +31,28 @@ export default {
       current: null
     }
   },
+  mounted: function () {
+    let initial = this.$route.query[this.name]
+    if (initial) {
+      this.current = isNaN(parseInt(initial)) ? initial : this.choices[initial]
+    }
+  },
   methods: {
-    select: function (choice) {
+    select: function (choice, evt) {
+      evt.stopPropagation()
+
+      // Save new choice
       this.current = choice
       this.$emit('new-choice', choice)
+
+      // Set value in the url for sharing
+      var query = Object.assign({}, this.$route.query)
+      if (choice !== null) {
+        query[this.name] = typeof choice === 'string' ? choice : this.choices.indexOf(choice)
+      } else if (this.name in query) {
+        delete query[this.name]
+      }
+      this.$router.push({ 'query': query })
     }
   },
   computed: {

--- a/src/staticanalysis/frontend/src/Task.vue
+++ b/src/staticanalysis/frontend/src/Task.vue
@@ -10,6 +10,7 @@ export default {
       state: 'loading',
       filters: {
         publishable: null,
+        analyzer: null,
         path: null
       },
       choices: {
@@ -49,9 +50,17 @@ export default {
       if (!this.report) {
         return null
       }
-      // List sorted unique path as choices
+      // List sorted unique paths as choices
       let paths = _.sortBy(_.uniq(_.map(this.report.issues, 'path')))
       return _.map(paths, path => Object({ 'name': path }))
+    },
+    analyzers () {
+      if (!this.report) {
+        return null
+      }
+      // List sorted unique analyzers as choices
+      let analyzers = _.sortBy(_.uniq(_.map(this.report.issues, 'analyzer')))
+      return _.map(analyzers, analyzer => Object({ 'name': analyzer }))
     },
     nb_publishable () {
       if (!this.report || !this.report.issues) {
@@ -70,6 +79,11 @@ export default {
       // Filter by path
       if (this.filters.path !== null) {
         issues = _.filter(issues, i => i.path === this.filters.path.name)
+      }
+
+      // Filter by analyzer
+      if (this.filters.analyzer !== null) {
+        issues = _.filter(issues, i => i.analyzer === this.filters.analyzer.name)
       }
 
       // Always display publishable first
@@ -123,7 +137,7 @@ export default {
       <table class="table is-fullwidth" v-if="issues">
         <thead>
           <tr>
-            <td>Analyzer</td>
+            <td><Choice :choices="analyzers" name="analyzer" v-on:new-choice="filters.analyzer = $event"/></td>
             <td><Choice :choices="paths" name="path" v-on:new-choice="filters.path = $event"/></td>
             <td>Lines</td>
             <td><Choice :choices="choices.publishable" name="issue" v-on:new-choice="filters.publishable = $event"/></td>

--- a/src/staticanalysis/frontend/src/Task.vue
+++ b/src/staticanalysis/frontend/src/Task.vue
@@ -32,6 +32,13 @@ export default {
     Choice
   },
   mounted () {
+    // Update filters from query string
+    let publishable = parseInt(this.$route.query.issue)
+    this.filters.publishable = isNaN(publishable) ? null : this.choices.publishable[publishable]
+    this.filters.path = this.$route.query.path || null
+    this.filters.analyzer = this.$route.query.analyzer || null
+
+    // Load report
     var report = this.$store.dispatch('load_report', this.$route.params.taskId)
     report.then(
       (response) => {

--- a/src/staticanalysis/frontend/src/Task.vue
+++ b/src/staticanalysis/frontend/src/Task.vue
@@ -51,16 +51,14 @@ export default {
         return null
       }
       // List sorted unique paths as choices
-      let paths = _.sortBy(_.uniq(_.map(this.report.issues, 'path')))
-      return _.map(paths, path => Object({ 'name': path }))
+      return _.sortBy(_.uniq(_.map(this.report.issues, 'path')))
     },
     analyzers () {
       if (!this.report) {
         return null
       }
       // List sorted unique analyzers as choices
-      let analyzers = _.sortBy(_.uniq(_.map(this.report.issues, 'analyzer')))
-      return _.map(analyzers, analyzer => Object({ 'name': analyzer }))
+      return _.sortBy(_.uniq(_.map(this.report.issues, 'analyzer')))
     },
     nb_publishable () {
       if (!this.report || !this.report.issues) {
@@ -78,12 +76,12 @@ export default {
 
       // Filter by path
       if (this.filters.path !== null) {
-        issues = _.filter(issues, i => i.path === this.filters.path.name)
+        issues = _.filter(issues, i => i.path === this.filters.path)
       }
 
       // Filter by analyzer
       if (this.filters.analyzer !== null) {
-        issues = _.filter(issues, i => i.analyzer === this.filters.analyzer.name)
+        issues = _.filter(issues, i => i.analyzer === this.filters.analyzer)
       }
 
       // Always display publishable first

--- a/src/staticanalysis/frontend/src/Task.vue
+++ b/src/staticanalysis/frontend/src/Task.vue
@@ -7,7 +7,22 @@ export default {
   name: 'Task',
   data () {
     return {
-      state: 'loading'
+      state: 'loading',
+      filters: {
+        publishable: null
+      },
+      choices: {
+        publishable: [
+          {
+            name: 'Publishable',
+            func: i => i.publishable
+          },
+          {
+            name: 'Non publishable',
+            func: i => !i.publishable
+          }
+        ]
+      }
     }
   },
   components: {
@@ -37,6 +52,11 @@ export default {
     },
     issues () {
       let issues = this.report ? this.report.issues : []
+
+      // Filter by publishable
+      if (this.filters.publishable !== null) {
+        issues = _.filter(issues, this.filters.publishable.func)
+      }
 
       // Always display publishable first
       return _.sortBy(issues, i => !i.publishable)
@@ -92,7 +112,7 @@ export default {
             <td>Analyzer</td>
             <td>Path</td>
             <td>Lines</td>
-            <td>Publication</td>
+            <td><Choice :choices="choices.publishable" name="issue" v-on:new-choice="filters.publishable = $event"/></td>
             <td>Check</td>
             <td>Level</td>
             <td>Message</td>

--- a/src/staticanalysis/frontend/src/Task.vue
+++ b/src/staticanalysis/frontend/src/Task.vue
@@ -1,5 +1,8 @@
 <script>
 import Bool from './Bool.vue'
+import _ from 'lodash'
+import Choice from './Choice.vue'
+
 export default {
   name: 'Task',
   data () {
@@ -8,7 +11,8 @@ export default {
     }
   },
   components: {
-    Bool
+    Bool,
+    Choice
   },
   mounted () {
     var report = this.$store.dispatch('load_report', this.$route.params.taskId)
@@ -30,6 +34,12 @@ export default {
         return 0
       }
       return this.report.issues.filter(i => i.publishable).length
+    },
+    issues () {
+      let issues = this.report ? this.report.issues : []
+
+      // Always display publishable first
+      return _.sortBy(issues, i => !i.publishable)
     }
   },
   filters: {
@@ -76,7 +86,7 @@ export default {
         </div>
       </nav>
 
-      <table class="table is-fullwidth" v-if="report && report.issues">
+      <table class="table is-fullwidth" v-if="issues">
         <thead>
           <tr>
             <td>Analyzer</td>
@@ -90,7 +100,7 @@ export default {
         </thead>
 
         <tbody>
-          <tr v-for="issue in report.issues" :class="{'publishable': issue.publishable}">
+          <tr v-for="issue in issues" :class="{'publishable': issue.publishable}">
             <td>
               <span v-if="issue.analyzer == 'mozlint'">{{ issue.linter }}<br />by Mozlint</span>
               <span v-else>{{ issue.analyzer }}</span>
@@ -109,11 +119,13 @@ export default {
             <td>
               <span v-if="issue.analyzer == 'mozlint'">{{ issue.rule }}</span>
               <span v-if="issue.analyzer == 'clang-tidy'">{{ issue.check }}</span>
+              <span v-if="issue.analyzer == 'clang-format'">Style issue</span>
               <span v-if="issue.analyzer == 'infer'">{{ issue.bug_type }}</span>
+              <span v-if="issue.analyzer == 'Coverity'">{{ issue.bug_type }}<br /><code>{{ issue.kind }}</code></span>
             </td>
             <td>
-              <span v-if="issue.level == 'error' || issue.type == 'error' || issue.kind == 'ERROR'" class="tag is-danger">Error</span>
-              <span v-if="issue.level == 'warning' || issue.type == 'warning' || issue.kind == 'WARNING'" class="tag is-warning">Warning</span>
+              <span v-if="issue.level == 'error' || issue.type == 'error' || issue.kind == 'ERROR' || issue.analyzer == 'Coverity'" class="tag is-danger">Error</span>
+              <span v-if="issue.level == 'warning' || issue.type == 'warning' || issue.kind == 'WARNING' || issue.analyzer == 'clang-format'" class="tag is-warning">Warning</span>
             </td>
             <td>
               <pre v-if="issue.analyzer == 'Coverity'">{{ issue.message }}</pre>

--- a/src/staticanalysis/frontend/src/Task.vue
+++ b/src/staticanalysis/frontend/src/Task.vue
@@ -9,7 +9,8 @@ export default {
     return {
       state: 'loading',
       filters: {
-        publishable: null
+        publishable: null,
+        path: null
       },
       choices: {
         publishable: [
@@ -44,6 +45,14 @@ export default {
     report () {
       return this.$store.state.report
     },
+    paths () {
+      if (!this.report) {
+        return null
+      }
+      // List sorted unique path as choices
+      let paths = _.sortBy(_.uniq(_.map(this.report.issues, 'path')))
+      return _.map(paths, path => Object({ 'name': path }))
+    },
     nb_publishable () {
       if (!this.report || !this.report.issues) {
         return 0
@@ -56,6 +65,11 @@ export default {
       // Filter by publishable
       if (this.filters.publishable !== null) {
         issues = _.filter(issues, this.filters.publishable.func)
+      }
+
+      // Filter by path
+      if (this.filters.path !== null) {
+        issues = _.filter(issues, i => i.path === this.filters.path.name)
       }
 
       // Always display publishable first
@@ -110,7 +124,7 @@ export default {
         <thead>
           <tr>
             <td>Analyzer</td>
-            <td>Path</td>
+            <td><Choice :choices="paths" name="path" v-on:new-choice="filters.path = $event"/></td>
             <td>Lines</td>
             <td><Choice :choices="choices.publishable" name="issue" v-on:new-choice="filters.publishable = $event"/></td>
             <td>Check</td>


### PR DESCRIPTION
* Adds missing coverity fields in issue details
* Display publishable issues on top
* Filter issues by publishable status
* Filter issues by path
* Filter issues by analyzer
* Filters are set in the url and are shareable

It's deploying on testing, here is [a good example](https://static-analysis.testing.moz.tools/#/task/YJv8RMoVQfWeQRanN_Tv-A)