### PR TITLE
staticanalysis/frontend: Search by revision ID and load all tasks for diff

### DIFF
--- a/src/staticanalysis/frontend/src/Tasks.vue
+++ b/src/staticanalysis/frontend/src/Tasks.vue
@@ -55,7 +55,7 @@ export default {
       // Filter by revision
       if (this.filters.revision !== null) {
         tasks = _.filter(tasks, t => {
-          let payload = t.data.title + t.data.bugzilla_id + t.data.phid + t.data.diff_phid
+          let payload = t.data.title + t.data.bugzilla_id + t.data.phid + t.data.diff_phid + t.data.id
           return payload.toLowerCase().indexOf(this.filters.revision.toLowerCase()) !== -1
         })
       }
@@ -110,13 +110,15 @@ export default {
             <a class="mono" :href="'https://tools.taskcluster.net/task-inspector/#' + task.taskId" target="_blank">{{ task.taskId }}</a>
           </td>
 
-          <td v-if="task.data.source == 'phabricator'">
+          <td>
             <p v-if="task.data.title">{{ task.data.title }}</p>
             <p class="has-text-danger" v-else>No title</p>
-            <small class="mono has-text-grey-light">{{ task.data.diff_phid}}</small>
-          </td>
-          <td v-else>
-            <p class="notification is-danger">Unknown data source: {{ task.data.source }}</p>
+            <p>
+              <small class="mono has-text-grey-light">{{ task.data.diff_phid}}</small>
+            </p>
+            <p>
+              <small class="mono has-text-grey-light">{{ task.data.phid}}</small> - rev {{ task.data.id }}
+            </p>
           </td>
 
           <td>

--- a/src/staticanalysis/frontend/src/store.js
+++ b/src/staticanalysis/frontend/src/store.js
@@ -190,7 +190,7 @@ export default new Vuex.Store({
 
     // Load Phabricator indexed tasks summary from Taskcluster
     load_index (state, payload) {
-      let url = TASKCLUSTER_INDEX + '/tasks/project.releng.services.project.' + this.state.channel + '.static_analysis_bot.phabricator'
+      let url = TASKCLUSTER_INDEX + '/tasks/project.releng.services.project.' + this.state.channel + '.static_analysis_bot.phabricator.diff'
       url += '?limit=200'
       if (payload && payload.continuationToken) {
         url += '&continuationToken=' + payload.continuationToken


### PR DESCRIPTION
While working on #1754, i noticed a bad behaviour in the SA frontend: only the last analysis task of a revision was displayed !
This [sample revision](https://phabricator.services.mozilla.com/D19250) has 16 diffs, and 5 analysis tasks (when looking in papertrail logs). But the static analysis dashboard in production only show the one when looking for the revision phid:
![](https://i.imgur.com/hFVXe3f.png)

So i made that PR to do the following:

1. Use the `phabricator.diff` route (indexing by diff) instead of `phabricator` (indexing by revision)
2. Display the revision phid & id on the tasks list
3. Allow searching by revision ID (much easier to find than the revision PHID)

Which gives us a way better state:

![](https://i.imgur.com/3HmyDSg.png)

