### PR TITLE
Remove mercurial clone cache

### DIFF
--- a/src/staticanalysis/bot/default.nix
+++ b/src/staticanalysis/bot/default.nix
@@ -21,7 +21,6 @@ let
 
   mkBot = branch:
     let
-      cacheKey = "services-" + branch + "-static-analysis-bot";
       secretsKey = "repo:github.com/mozilla-releng/services:branch:" + branch;
       hook = mkTaskclusterHook {
         name = "Static analysis automated tests";
@@ -37,18 +36,12 @@ let
           # Send emails to relman
           "notify:email:*"
 
-          # Used by cache
-          ("docker-worker:cache:" + cacheKey)
-
           # Needed to index the task in the TaskCluster index
           ("index:insert-task:project.releng.services.project." + branch + ".static_analysis_bot.*")
 
           # Needed to download the Android sdks for Infer
           "queue:get-artifact:project/gecko/android-*"
         ];
-        cache = {
-          "${cacheKey}" = "/cache";
-        };
         taskEnv = mkTaskclusterMergeEnv {
           env = {
             "SSL_CERT_FILE" = "${cacert}/etc/ssl/certs/ca-bundle.crt";
@@ -67,8 +60,6 @@ let
           "/bin/static-analysis-bot"
           "--taskcluster-secret"
           secretsKey
-          "--cache-root"
-          "/cache"
         ];
         taskArtifacts = {
           "public/results" = {

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -42,18 +42,18 @@ logger = get_logger(__name__)
     envvar='TASK_ID',
 )
 @click.option(
-    '--cache-root',
+    '--work-dir',
     default=os.path.join(
         tempfile.gettempdir(),
         'staticanalysis',
     ),
-    help='Cache root, used to pull changesets'
+    help='Work directory, used to pull changesets'
 )
 @stats.api.timer('runtime.analysis')
 def main(source,
          id,
          task_id,
-         cache_root,
+         work_dir,
          taskcluster_secret,
          taskcluster_client_id,
          taskcluster_access_token,
@@ -91,7 +91,7 @@ def main(source,
     # Setup settings before stats
     settings.setup(
         secrets['APP_CHANNEL'],
-        cache_root,
+        work_dir,
         source,
         secrets['PUBLICATION'],
         secrets['ALLOWED_PATHS'],

--- a/src/staticanalysis/bot/static_analysis_bot/config.py
+++ b/src/staticanalysis/bot/static_analysis_bot/config.py
@@ -47,7 +47,6 @@ class Settings(object):
 
         # Paths
         self.has_local_clone = True
-        self.cache_root = None
         self.repo_dir = None
         self.repo_shared_dir = None
         self.taskcluster = None
@@ -62,7 +61,7 @@ class Settings(object):
 
     def setup(self,
               app_channel,
-              cache_root,
+              work_dir,
               source,
               publication,
               allowed_paths,
@@ -87,11 +86,10 @@ class Settings(object):
         except KeyError:
             raise Exception('Publication mode should be {}'.format('|'.join(map(lambda p: p .name, Publication))))
 
-        if not os.path.isdir(cache_root):
-            os.makedirs(cache_root)
-        self.cache_root = cache_root
-        self.repo_dir = os.path.join(self.cache_root, 'sa-unified')
-        self.repo_shared_dir = os.path.join(self.cache_root, 'sa-unified-shared')
+        if not os.path.isdir(work_dir):
+            os.makedirs(work_dir)
+        self.repo_dir = os.path.join(work_dir, 'sa-unified')
+        self.repo_shared_dir = os.path.join(work_dir, 'sa-unified-shared')
 
         # Save Taskcluster ID for logging
         if 'TASK_ID' in os.environ and 'RUN_ID' in os.environ:


### PR DESCRIPTION
I renamed `cache_root` to `work_dir` as it's still useful for developers to specify a static path

Fixes #1923.