### PR TITLE
Display time & logs for mercurial clone

### DIFF
--- a/lib/cli_common/cli_common/log.py
+++ b/lib/cli_common/cli_common/log.py
@@ -133,6 +133,7 @@ def init_logger(project_name,
                 SENTRY_DSN=None,
                 MOZDEF=None,
                 flask_app=None,
+                timestamp=False,
                 ):
 
     if not channel:
@@ -167,6 +168,8 @@ def init_logger(project_name,
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
     ]
+    if timestamp is True:
+        processors.append(structlog.processors.TimeStamper(fmt='%Y-%m-%d %H:%M:%S'))
 
     # send to mozdef before formatting into a string
     if channel and MOZDEF:

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -86,6 +86,7 @@ def main(source,
                 PAPERTRAIL_PORT=secrets.get('PAPERTRAIL_PORT'),
                 SENTRY_DSN=secrets.get('SENTRY_DSN'),
                 MOZDEF=secrets.get('MOZDEF'),
+                timestamp=True,
                 )
 
     # Setup settings before stats

--- a/src/staticanalysis/bot/static_analysis_bot/workflows/local.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflows/local.py
@@ -86,7 +86,7 @@ class LocalWorkflow(object):
             fcntl.fcntl(
                 output.fileno(),
                 fcntl.F_SETFL,
-                fcntl.fcntl(proc.stdout.fileno(), fcntl.F_GETFL) | os.O_NONBLOCK,
+                fcntl.fcntl(output, fcntl.F_GETFL) | os.O_NONBLOCK,
             )
 
         while proc.poll() is None:


### PR DESCRIPTION
Sample output:

```
static_analysis_bot.config: Loaded configuration from mozilla-central (timestamp='2019-03-04 16:49:01')
datadog.threadstats: Starting flush thread with interval 10.
static_analysis_bot.report.mail: Mail report enabled (emails=['babadie@mozilla.com', 'sledru@mozilla.com', 'andi@mozilla.com'] timestamp='2019-03-04 16:49:01')
cli_common.phabricator: Authenticated on https://phabricator.services.mozilla.com/api/ as Code Review Bot (timestamp='2019-03-04 16:49:02')
static_analysis_bot.workflows.base: Skipping taskcluster indexing (rev='Phabricator #66043 - PHID-DIFF-uhnq6b5tekvkdhyiuzay' state='started' timestamp='2019-03-04 16:49:04')
static_analysis_bot.workflows.local: New static analysis (taskcluster_task='local instance' taskcluster_run=0 channel='staging' publication='BEFORE_AFTER' revision='Phabricator #66043 - PHID-DIFF-uhnq6b5tekvkdhyiuzay' timestamp='2019-03-04 16:49:04')
static_analysis_bot.workflows.local: Clone mozilla unified (dir='/app/tmp/sa-unified' timestamp='2019-03-04 16:49:04')
static_analysis_bot.workflows.local: clone: (using Mercurial 4.8) (timestamp='2019-03-04 16:49:06')
static_analysis_bot.workflows.local: clone: ensuring https://hg.mozilla.org/mozilla-unified@central is available at /app/tmp/sa-unified (timestamp='2019-03-04 16:49:08')
static_analysis_bot.workflows.local: clone: (existing repository shared store: /app/tmp/sa-unified-shared/8ba995b74e18334ab3707f27e9eb8f4e37ba3d29/.hg) (timestamp='2019-03-04 16:49:08')
static_analysis_bot.workflows.local: clone: (pulling to obtain central) (timestamp='2019-03-04 16:49:08')
static_analysis_bot.workflows.local: clone: (remote resolved central to fd67a4332060ea5389d448b3453ea23064e50b5e; result is not deterministic) (timestamp='2019-03-04 16:49:08')
static_analysis_bot.workflows.local: clone: (revision already present locally; not pulling) (timestamp='2019-03-04 16:49:08')
datadog.api: 202 POST https://api.datadoghq.com/api/v1/series (416.7638ms)
datadog.api: 202 POST https://api.datadoghq.com/api/v1/events (104.1481ms)
static_analysis_bot.workflows.local: clone: (purging working directory) (timestamp='2019-03-04 16:48:39')
updating [==============================>                                                                                 ]  3800/13332 06s (timestamp='2019-03-04 16:48:41')
updating [==================================================>                                                             ]  6100/13332 04s (timestamp='2019-03-04 16:48:42')
updating [======================================================================>                                         ]  8500/13332 03s (timestamp='2019-03-04 16:48:43')
updating [===========================================================================================>                    ] 11000/13332 02s (timestamp='2019-03-04 16:48:44')
updating [=============================================================================================================>  ] 13199/13332 01s (timestamp='2019-03-04 16:48:45')
static_analysis_bot.cli: Static analysis failure (revision=PHID-DIFF-uhnq6b5tekvkdhyiuzay error=TypeError("'float' object is not callable") timestamp='2019-03-04 16:48:46')
static_analysis_bot.workflows.local: Clone finished (time=12.015639543533325 out=b'(purging working directory)\n0 files updated, 0 files merged, 0 files removed, 0 files unresolved\nupdated to fd67a4332060ea5389d448b3453ea23064e50b5e\n' err=None timestamp='2019-03-04 16:49:16')
static_analysis_bot.workflows.local: Mercurial out=515739fd67a4332060ea5389d448b3453ea23064e50b5edefaultDaniel Varga <dvarga@mozilla.com>Merge mozilla-inbound to mozilla-central. a=merge1551692251.0-7200 (timestamp='2019-03-04 16:49:17')
static_analysis_bot.workflows.local: Mozilla unified top revision (revision=b'fd67a4332060ea5389d448b3453ea23064e50b5e' timestamp='2019-03-04 16:49:17')
static_analysis_bot.workflows.base: Skipping taskcluster indexing (rev='Phabricator #66043 - PHID-DIFF-uhnq6b5tekvkdhyiuzay' state='cloned' timestamp='2019-03-04 16:49:17')
static_analysis_bot.workflows.local: Mercurial out=0 files updated, 0 files merged, 0 files removed, 0 files unresolved
 (timestamp='2019-03-04 16:49:20')

```