### PR TITLE
List static analysis tasks for a phabricator revision

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/workflows/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflows/base.py
@@ -128,8 +128,15 @@ class Workflow(object):
         now = datetime.utcnow()
         payload['indexed'] = now.strftime(TASKCLUSTER_DATE_FORMAT)
 
+        # Add a sub namespace with the task id to be able to list
+        # tasks from the parent namespace
+        namespaces = revision.namespaces + [
+            '{}.{}'.format(namespace, settings.taskcluster.task_id)
+            for namespace in revision.namespaces
+        ]
+
         # Index for all required namespaces
-        for name in revision.namespaces:
+        for name in namespaces:
             namespace = TASKCLUSTER_NAMESPACE.format(channel=settings.app_channel, name=name)
             self.index_service.insertTask(
                 namespace,

--- a/src/staticanalysis/bot/tests/test_workflow.py
+++ b/src/staticanalysis/bot/tests/test_workflow.py
@@ -18,10 +18,23 @@ def test_taskcluster_index(mock_workflow, mock_config, mock_revision):
     mock_revision.as_dict = lambda: {'id': '1234', 'source': 'mock'}
     mock_workflow.index(mock_revision, test='dummy')
 
-    args = mock_workflow.index_service.insertTask.call_args[0]
-    assert args[0] == 'project.releng.services.project.test.static_analysis_bot.mock.1234'
-    assert args[1]['taskId'] == '12345deadbeef'
-    assert args[1]['data']['test'] == 'dummy'
-    assert args[1]['data']['id'] == '1234'
-    assert args[1]['data']['source'] == 'mock'
-    assert 'indexed' in args[1]['data']
+    assert mock_workflow.index_service.insertTask.call_count == 2
+    calls = mock_workflow.index_service.insertTask.call_args_list
+
+    # First call with namespace
+    namespace, args = calls[0][0]
+    assert namespace == 'project.releng.services.project.test.static_analysis_bot.mock.1234'
+    assert args['taskId'] == '12345deadbeef'
+    assert args['data']['test'] == 'dummy'
+    assert args['data']['id'] == '1234'
+    assert args['data']['source'] == 'mock'
+    assert 'indexed' in args['data']
+
+    # Second call with sub namespace
+    namespace, args = calls[1][0]
+    assert namespace == 'project.releng.services.project.test.static_analysis_bot.mock.1234.12345deadbeef'
+    assert args['taskId'] == '12345deadbeef'
+    assert args['data']['test'] == 'dummy'
+    assert args['data']['id'] == '1234'
+    assert args['data']['source'] == 'mock'
+    assert 'indexed' in args['data']

--- a/src/staticanalysis/frontend/src/Tasks.vue
+++ b/src/staticanalysis/frontend/src/Tasks.vue
@@ -5,14 +5,28 @@ import Choice from './Choice.vue'
 
 export default {
   mounted () {
-    var payload = {}
-
-    // Load a specific revision only
-    if (this.$route.params.revision) {
-      payload['revision'] = this.$route.params.revision
+    // Load new tasks at startup
+    this.load_tasks()
+  },
+  watch: {
+    '$route' (to, from, next) {
+      // Load new tasks when route change
+      this.load_tasks()
     }
+  },
+  methods: {
+    load_tasks () {
+      var payload = {}
 
-    this.$store.dispatch('load_index', payload)
+      // Reset state
+      this.$store.commit('reset')
+
+      // Load a specific revision only
+      if (this.$route.params.revision) {
+        payload['revision'] = this.$route.params.revision
+      }
+      this.$store.dispatch('load_index', payload)
+    }
   },
   components: {
     Choice: Choice
@@ -124,7 +138,7 @@ export default {
               <small class="mono has-text-grey-light">{{ task.data.diff_phid}}</small> - diff {{ task.data.diff_id || 'unknown'     }}
             </p>
             <p>
-              <small class="mono has-text-grey-light">{{ task.data.phid}}</small> - rev {{ task.data.id }}
+              <small class="mono has-text-grey-light">{{ task.data.phid}}</small> - <router-link :to="{ name: 'revision', params: { revision: task.data.id }}">rev {{ task.data.id }}</router-link>
             </p>
           </td>
 

--- a/src/staticanalysis/frontend/src/Tasks.vue
+++ b/src/staticanalysis/frontend/src/Tasks.vue
@@ -5,7 +5,14 @@ import Choice from './Choice.vue'
 
 export default {
   mounted () {
-    this.$store.dispatch('load_index')
+    var payload = {}
+
+    // Load a specific revision only
+    if (this.$route.params.revision) {
+      payload['revision'] = this.$route.params.revision
+    }
+
+    this.$store.dispatch('load_index', payload)
   },
   components: {
     Choice: Choice

--- a/src/staticanalysis/frontend/src/routes.js
+++ b/src/staticanalysis/frontend/src/routes.js
@@ -16,7 +16,7 @@ export default new VueRouter({
     },
     {
       path: '/rev/:revision',
-      name: 'tasks',
+      name: 'revision',
       component: Tasks
     },
     {

--- a/src/staticanalysis/frontend/src/routes.js
+++ b/src/staticanalysis/frontend/src/routes.js
@@ -15,6 +15,11 @@ export default new VueRouter({
       component: Tasks
     },
     {
+      path: '/rev/:revision',
+      name: 'tasks',
+      component: Tasks
+    },
+    {
       path: '/task/:taskId',
       name: 'task',
       component: Task

--- a/src/staticanalysis/frontend/src/store.js
+++ b/src/staticanalysis/frontend/src/store.js
@@ -204,7 +204,14 @@ export default new Vuex.Store({
 
     // Load Phabricator indexed tasks summary from Taskcluster
     load_index (state, payload) {
-      let url = TASKCLUSTER_INDEX + '/tasks/project.releng.services.project.' + this.state.channel + '.static_analysis_bot.phabricator.diff'
+      let url = TASKCLUSTER_INDEX + '/tasks/project.releng.services.project.' + this.state.channel + '.static_analysis_bot.phabricator.'
+      if (payload && payload.revision) {
+        // Remove potential leading 'D' from phabricator revision
+        url += payload.revision.startsWith('D') ? payload.revision.substring(1) : payload.revision
+      } else {
+        url += 'diff'
+      }
+
       url += '?limit=200'
       if (payload && payload.continuationToken) {
         url += '&continuationToken=' + payload.continuationToken

--- a/src/staticanalysis/frontend/src/store.js
+++ b/src/staticanalysis/frontend/src/store.js
@@ -48,8 +48,10 @@ export default new Vuex.Store({
     },
     use_channel (state, channel) {
       state.channel = channel
-
-      // Reset state
+      this.commit('reset')
+      this.commit('save_preferences')
+    },
+    reset (state) {
       state.tasks = []
       state.indexes = []
       state.stats = {
@@ -59,7 +61,6 @@ export default new Vuex.Store({
         checks: {},
         start_date: new Date()
       }
-      this.commit('save_preferences')
     },
     use_tasks (state, payload) {
       var now = new Date()
@@ -207,7 +208,7 @@ export default new Vuex.Store({
       let url = TASKCLUSTER_INDEX + '/tasks/project.releng.services.project.' + this.state.channel + '.static_analysis_bot.phabricator.'
       if (payload && payload.revision) {
         // Remove potential leading 'D' from phabricator revision
-        url += payload.revision.startsWith('D') ? payload.revision.substring(1) : payload.revision
+        url += !Number.isInteger(payload.revision) && payload.revision.startsWith('D') ? payload.revision.substring(1) : payload.revision
       } else {
         url += 'diff'
       }


### PR DESCRIPTION
I want to display efficiently all the static analysis tasks for a given phabricator revision. Currently we have to load all the tasks in the index, and filter the output.
A better usage of taskcluster index would allow to list directlty the tasks in a given namespace (by indexing the task in a sub-namespace)

In the end, an url like: `https://static-analysis.moz.tools/#/rev/D12345` should list all the tasks from `D12345`, so that a developer can view the current state on our side.

We could then **always** post a comment on the revision during the first task to display the link.

EDIT: after discussion, we won't post automatically the link.