### PR TITLE
shipit/api: fix slugid usage

### DIFF
--- a/src/shipit/api/shipit_api/models.py
+++ b/src/shipit/api/shipit_api/models.py
@@ -163,7 +163,7 @@ class Release(db.Model):
     def phase_signoffs(branch, product, phase):
         return [
             Signoff(
-                uid=slugid.nice()
+                uid=slugid.nice(),
                 name=req['name'],
                 description=req['description'],
                 permissions=req['permissions']

--- a/src/shipit/api/shipit_api/models.py
+++ b/src/shipit/api/shipit_api/models.py
@@ -163,7 +163,7 @@ class Release(db.Model):
     def phase_signoffs(branch, product, phase):
         return [
             Signoff(
-                uid=slugid.nice().decode('utf-8'),
+                uid=slugid.nice()
                 name=req['name'],
                 description=req['description'],
                 permissions=req['permissions']

--- a/src/shipit/api/shipit_api/tasks.py
+++ b/src/shipit/api/shipit_api/tasks.py
@@ -76,7 +76,7 @@ def extract_our_flavors(avail_flavors, product, version, partial_updates):
 def generate_action_task(decision_task_id, action_name, input_, actions):
     target_action = find_action(action_name, actions)
     context = copy.deepcopy(actions['variables'])  # parameters
-    action_task_id = slugid.nice().decode('utf-8')
+    action_task_id = slugid.nice()
     context.update({
         'input': input_,
         'taskGroupId': decision_task_id,


### PR DESCRIPTION
In version 2.0.0 slugid started using strings instead of bytes.

Quote:
    "Slugs are generated with the interpreter's default string type. On
    Python 2, these are byte strings.  On Python 3, these are unicode
    strings."