### PR TITLE
Nicer Try commit messages

### DIFF
--- a/lib/cli_common/cli_common/phabricator.py
+++ b/lib/cli_common/cli_common/phabricator.py
@@ -141,7 +141,12 @@ class PhabricatorAPI(object):
         '''
         constraints = {}
         if diff_phid is not None:
-            constraints['phids'] = [diff_phid, ]
+            if isinstance(diff_phid, str):
+                constraints['phids'] = [diff_phid, ]
+            elif isinstance(diff_phid, list):
+                constraints['phids'] = diff_phid
+            else:
+                raise Exception('diff_phid must be a string or a list')
         if revision_phid is not None:
             constraints['revisionPHIDs'] = [revision_phid, ]
         out = self.request('differential.diff.search', constraints=constraints, **params)

--- a/src/pulselistener/pulselistener/mercurial.py
+++ b/src/pulselistener/pulselistener/mercurial.py
@@ -115,12 +115,30 @@ class MercurialWorker(object):
         base, patches = self.phabricator_api.load_patches_stack(self.repo, diff, default_revision='central')
         assert len(patches) > 0, 'No patches to apply'
 
+        # Load all the diffs details with commits messages
+        diffs = self.phabricator_api.search_diffs(
+            diff_phid=[p[0] for p in patches],
+            attachments={
+                'commits': True,
+            }
+        )
+        commits = {
+            diff['phid']: diff['attachments']['commits'].get('commits', [])
+            for diff in diffs
+        }
+
         # Apply the patches and commit them one by one
         for diff_phid, patch in patches:
-            logger.info('Applying patch', phid=diff_phid)
+            commit = commits.get(diff_phid)
+            if commit:
+                message = '{}\nDiff: {}'.format(commit[0]['message'], diff_phid)
+            else:
+                message = 'Diff: {}'.format(diff_phid)
+
+            logger.info('Applying patch', phid=diff_phid, message=message)
             self.repo.import_(
                 patches=io.BytesIO(patch.encode('utf-8')),
-                message='Patch {}'.format(diff_phid),
+                message=message,
                 user='pulselistener',
             )
 
@@ -135,10 +153,10 @@ class MercurialWorker(object):
             }
         }
         with open(config_path, 'w') as f:
-            json.dump(config, f)
+            json.dump(config, f, sort_keys=True, indent=4)
         self.repo.add(config_path.encode('utf-8'))
         self.repo.commit(
-            message='try_task_config for {}'.format(diff['phid']),
+            message='try_task_config for code-review\nDiff: {}'.format(diff['phid']),
             user='pulselistener',
         )
 

--- a/src/pulselistener/pulselistener/mercurial.py
+++ b/src/pulselistener/pulselistener/mercurial.py
@@ -131,9 +131,8 @@ class MercurialWorker(object):
         for diff_phid, patch in patches:
             commit = commits.get(diff_phid)
             if commit:
-                message = '{}\nDiff: {}'.format(commit[0]['message'], diff_phid)
-            else:
-                message = 'Diff: {}'.format(diff_phid)
+                message = '{}\n'.format(commit[0]['message'])
+            message += 'Differential Diff: {}'.format(diff_phid)
 
             logger.info('Applying patch', phid=diff_phid, message=message)
             self.repo.import_(
@@ -156,7 +155,7 @@ class MercurialWorker(object):
             json.dump(config, f, sort_keys=True, indent=4)
         self.repo.add(config_path.encode('utf-8'))
         self.repo.commit(
-            message='try_task_config for code-review\nDiff: {}'.format(diff['phid']),
+            message='try_task_config for code-review\nDifferential Diff: {}'.format(diff['phid']),
             user='pulselistener',
         )
 

--- a/src/pulselistener/tests/conftest.py
+++ b/src/pulselistener/tests/conftest.py
@@ -126,8 +126,16 @@ def PhabricatorMock():
     def _diff_search(request):
         params = _phab_params(request)
         assert 'constraints' in params
-        rev = params['constraints']['revisionPHIDs'][0]
-        return (200, json_headers, _response('search-{}'.format(rev)))
+        if 'revisionPHIDs' in params['constraints']:
+            # Search from revision
+            mock_name = 'search-{}'.format(params['constraints']['revisionPHIDs'][0])
+        elif 'phids' in params['constraints']:
+            # Search from diffs
+            diffs = '-'.join(params['constraints']['phids'])
+            mock_name = 'search-{}'.format(diffs)
+        else:
+            raise Exception('Unsupported diff mock {}'.format(params))
+        return (200, json_headers, _response(mock_name))
 
     def _diff_raw(request):
         params = _phab_params(request)

--- a/src/pulselistener/tests/mocks/phabricator/search-PHID-DIFF-solo.json
+++ b/src/pulselistener/tests/mocks/phabricator/search-PHID-DIFF-solo.json
@@ -1,0 +1,53 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 456,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-solo",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-zzzzz",
+                    "authorPHID": "PHID-USER-xxxxx",
+                    "repositoryPHID": "PHID-REPO-aaaaaa",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "coffeedeadbeef123456789"
+                        }
+                    ],
+                    "dateCreated": 1510251135,
+                    "dateModified": 1510251138,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {
+                  "commits": {
+                    "commits": [
+                      {
+                        "message": "A nice human readable commit message"
+                      }
+                    ]
+                  }
+                }
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}
+

--- a/src/pulselistener/tests/mocks/phabricator/search-PHID-DIFF-xxxx-PHID-DIFF-test123.json
+++ b/src/pulselistener/tests/mocks/phabricator/search-PHID-DIFF-xxxx-PHID-DIFF-test123.json
@@ -1,0 +1,87 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 123,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-xxxx",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-zzzzz",
+                    "authorPHID": "PHID-USER-xxxxx",
+                    "repositoryPHID": "PHID-REPO-aaaaaa",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "coffeedeadbeef123456789"
+                        }
+                    ],
+                    "dateCreated": 1510251135,
+                    "dateModified": 1510251138,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {
+                  "commits": {
+                    "commits": [
+                      {
+                        "message": "Bug XXX - A first commit message"
+                      }
+                    ]
+                  }
+                }
+            },
+            {
+                "id": 456,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-test123",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-zzzzz",
+                    "authorPHID": "PHID-USER-xxxxx",
+                    "repositoryPHID": "PHID-REPO-aaaaaa",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "coffeedeadbeef123456789"
+                        }
+                    ],
+                    "dateCreated": 1510251135,
+                    "dateModified": 1510251138,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {
+                  "commits": {
+                    "commits": [
+                      {
+                        "message": "Bug XXX - A second commit message"
+                      }
+                    ]
+                  }
+                }
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}
+

--- a/src/pulselistener/tests/test_mercurial.py
+++ b/src/pulselistener/tests/test_mercurial.py
@@ -65,9 +65,9 @@ async def test_push_to_try(PhabricatorMock, RepoMock):
 
     # Check all commits messages
     assert [c.desc for c in RepoMock.log()] == [
-        b'try_task_config for code-review\nDiff: PHID-DIFF-test123',
-        b'Bug XXX - A second commit message\nDiff: PHID-DIFF-test123',
-        b'Bug XXX - A first commit message\nDiff: PHID-DIFF-xxxx',
+        b'try_task_config for code-review\nDifferential Diff: PHID-DIFF-test123',
+        b'Bug XXX - A second commit message\nDifferential Diff: PHID-DIFF-test123',
+        b'Bug XXX - A first commit message\nDifferential Diff: PHID-DIFF-xxxx',
         b'Readme'
     ]
 
@@ -148,7 +148,7 @@ async def test_push_to_try_existing_rev(PhabricatorMock, RepoMock):
     # It should be different from the initial one (patches and config have applied)
     tip = RepoMock.tip()
     assert tip.node != base
-    assert tip.desc == b'try_task_config for code-review\nDiff: PHID-DIFF-solo'
+    assert tip.desc == b'try_task_config for code-review\nDifferential Diff: PHID-DIFF-solo'
 
     # Check the push to try has been called
     # with tip commit
@@ -164,7 +164,7 @@ async def test_push_to_try_existing_rev(PhabricatorMock, RepoMock):
     parents = RepoMock.parents(tip.node)
     assert len(parents) == 1
     parent = parents[0]
-    assert parent.desc == b'A nice human readable commit message\nDiff: PHID-DIFF-solo'
+    assert parent.desc == b'A nice human readable commit message\nDifferential Diff: PHID-DIFF-solo'
 
     # Check the grand parent is the base, not extra
     great_parents = RepoMock.parents(parent.node)

--- a/src/pulselistener/tests/test_mercurial.py
+++ b/src/pulselistener/tests/test_mercurial.py
@@ -63,6 +63,14 @@ async def test_push_to_try(PhabricatorMock, RepoMock):
     tip = RepoMock.tip()
     assert tip.node != initial.node
 
+    # Check all commits messages
+    assert [c.desc for c in RepoMock.log()] == [
+        b'try_task_config for code-review\nDiff: PHID-DIFF-test123',
+        b'Bug XXX - A second commit message\nDiff: PHID-DIFF-test123',
+        b'Bug XXX - A first commit message\nDiff: PHID-DIFF-xxxx',
+        b'Readme'
+    ]
+
     # Check the push to try has been called
     # with tip commit
     ssh_conf = 'ssh -o StrictHostKeyChecking="no" -o User="john@doe.com" -o IdentityFile="{}"'.format(worker.ssh_key_path)
@@ -140,7 +148,7 @@ async def test_push_to_try_existing_rev(PhabricatorMock, RepoMock):
     # It should be different from the initial one (patches and config have applied)
     tip = RepoMock.tip()
     assert tip.node != base
-    assert tip.desc == b'try_task_config for PHID-DIFF-solo'
+    assert tip.desc == b'try_task_config for code-review\nDiff: PHID-DIFF-solo'
 
     # Check the push to try has been called
     # with tip commit
@@ -156,7 +164,7 @@ async def test_push_to_try_existing_rev(PhabricatorMock, RepoMock):
     parents = RepoMock.parents(tip.node)
     assert len(parents) == 1
     parent = parents[0]
-    assert parent.desc == b'Patch PHID-DIFF-solo'
+    assert parent.desc == b'A nice human readable commit message\nDiff: PHID-DIFF-solo'
 
     # Check the grand parent is the base, not extra
     great_parents = RepoMock.parents(parent.node)


### PR DESCRIPTION
As requested on IRC, i modified the messages for our Try pushes commits by reusing the original message from developer. In most cases the Phabricator revision URL is already present in that message.


Fixes #1990 .