### PR TITLE
Upgrade clang 7 to 8

### DIFF
--- a/nix/gecko_env.nix
+++ b/nix/gecko_env.nix
@@ -5,10 +5,10 @@ let
   inherit (releng_pkgs.pkgs) rustChannelOf bash autoconf213 gcc-unwrapped glibc fetchFromGitHub unzip zip openjdk python2Packages sqlite zlib nasm;
   inherit (releng_pkgs.pkgs.devEnv) gecko;
 
-  clang = releng_pkgs.pkgs.clang_7;
+  clang = releng_pkgs.pkgs.clang_8;
   clang-tools = releng_pkgs.pkgs.clang-tools.override { inherit llvmPackages; };
-  llvm = releng_pkgs.pkgs.llvm_7;
-  llvmPackages = releng_pkgs.pkgs.llvmPackages_7;
+  llvm = releng_pkgs.pkgs.llvm_8;
+  llvmPackages = releng_pkgs.pkgs.llvmPackages_8;
 
   # Rust 1.32.0
   rustChannel' = rustChannelOf { date = "2019-01-17"; channel = "stable"; };


### PR DESCRIPTION
@garbas After updating the nixpkgs-channels revision, i get errors about missing `flake8` in the PATH (but it's installed accroding to the build log). Any idea ?

Also, how can i get the `sha256_tarball` value ?