### PR TITLE
Update Harbormaster status when using direct Taskcluster tasks

### DIFF
--- a/lib/cli_common/cli_common/phabricator.py
+++ b/lib/cli_common/cli_common/phabricator.py
@@ -396,6 +396,23 @@ class PhabricatorAPI(object):
             artifactData=payload,
         )
 
+    def create_harbormaster_uri(self, build_target_phid, artifact_key, name, uri, external=True):
+        '''
+        Helper to create a URI Harbormaster Artifact
+        '''
+        out = self.create_harbormaster_artifact(
+                build_target_phid=build_target_phid,
+                artifact_type=ArtifactType.Uri,
+                key=artifact_key,
+                payload={
+                    'uri': uri,
+                    'name': name,
+                    'ui.external': external,
+                },
+            )
+        logger.info('Created HarborMaster link', target=build_target_phid, uri=uri)
+        return out
+
     def upload_coverage_results(self, object_phid, coverage_data):
         '''
         Upload code coverage results to a Phabricator object.

--- a/src/pulselistener/pulselistener/listener.py
+++ b/src/pulselistener/pulselistener/listener.py
@@ -26,8 +26,6 @@ ACTION_TRY = 'try'
 MODE_PHABRICATOR_POLLING = 'polling'
 MODE_PHABRICATOR_WEBHOOK = 'webhook'
 
-TASK_URL = 'https://tools.taskcluster.net/task-inspector/#{}'
-
 
 class HookPhabricator(Hook):
     '''

--- a/src/pulselistener/pulselistener/listener.py
+++ b/src/pulselistener/pulselistener/listener.py
@@ -217,21 +217,11 @@ class HookPhabricator(Hook):
 
         # Create new task
         if ACTION_TASKCLUSTER in self.actions:
-            build_target_phid = diff.get('build_target_phid')
-            task_id = await self.create_task({
+            await self.create_task({
                 'ANALYSIS_SOURCE': 'phabricator',
                 'ANALYSIS_ID': diff['phid'],
-                'HARBORMASTER_TARGET': build_target_phid,
+                'HARBORMASTER_TARGET': diff.get('build_target_phid'),
             })
-
-            # Add link to Taskcluster on Phabricator build
-            if build_target_phid is not None:
-                self.api.create_harbormaster_uri(
-                    build_target_phid,
-                    artifact_key='taskcluster',
-                    name='Code Review Task',
-                    uri=TASK_URL.format(task_id),
-                )
         else:
             logger.info('Skipping Taskcluster task', diff=diff['phid'])
 

--- a/src/pulselistener/pulselistener/mercurial.py
+++ b/src/pulselistener/pulselistener/mercurial.py
@@ -15,7 +15,6 @@ import hglib
 
 from cli_common.log import get_logger
 from cli_common.mercurial import batch_checkout
-from cli_common.phabricator import ArtifactType
 from pulselistener.config import REPO_TRY
 
 logger = get_logger(__name__)
@@ -192,14 +191,4 @@ class MercurialWorker(object):
         build_target_phid = diff.get('build_target_phid')
         if build_target_phid:
             uri = TREEHERDER_URL.format(commit.node.decode('utf-8'))
-            self.phabricator_api.create_harbormaster_artifact(
-                build_target_phid=build_target_phid,
-                artifact_type=ArtifactType.Uri,
-                key='treeherder',
-                payload={
-                    'uri': uri,
-                    'name': 'Treeherder',
-                    'ui.external': True
-                },
-            )
-            logger.info('Published treeherder uri', target=build_target_phid, uri=uri)
+            self.phabricator_api.create_harbormaster_uri(build_target_phid, 'treeherder', 'Treeherder Jobs', uri)

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -233,13 +233,15 @@ class PhabricatorRevision(Revision):
         self.id = self.revision['id']
 
         # Load build for status updates
-        if settings.build_plan:
+        if 'HARBORMASTER_TARGET' in os.environ:
+            self.build_target_phid = os.environ['HARBORMASTER_TARGET']
+        elif settings.build_plan:
             build, targets = self.api.find_diff_build(self.diff_phid, settings.build_plan)
-            self.build_phid = build['phid']
+            build_phid = build['phid']
             nb = len(targets)
             assert nb > 0, 'No build target found'
             if nb > 1:
-                logger.warn('More than 1 build target found !', nb=nb, build_phid=self.build_phid)
+                logger.warn('More than 1 build target found !', nb=nb, build_phid=build_phid)
             target = targets[0]
             self.build_target_phid = target['phid']
         else:


### PR DESCRIPTION
- ~~Send Taskcluster link to Phabricator~~ :crying_cat_face: :it: 
- Provides the Harbormaster Target PHID to the SA task to avoid looking for it (and potentially missing it)