### PR TITLE
staticanalysis/bot: Consider having reviewbot provide more actionable clang-format and clang-tidy.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -14,7 +14,7 @@ from static_analysis_bot.lint import MozLintIssue
 COMMENT_PARTS = {
     ClangTidyIssue: {
         'defect': ' - {nb} found by clang-tidy',
-        'analyzer': ' - `./mach static-analysis check path/to/file.cpp` (C/C++)',
+        'analyzer': ' - `./mach static-analysis check {files}` (C/C++)',
     },
     InferIssue: {
         'defect': ' - {nb} found by infer',
@@ -25,7 +25,7 @@ COMMENT_PARTS = {
     },
     ClangFormatIssue: {
         'defect': ' - {nb} found by clang-format',
-        'analyzer': ' - `./mach clang-format -s -p path/to/file.cpp` (C/C++)',
+        'analyzer': ' - `./mach clang-format -s -p {files}` (C/C++)',
     },
     MozLintIssue: {
         'defect': ' - {nb} found by mozlint',
@@ -103,7 +103,8 @@ class Reporter(object):
             _items = list(items)
             return {
                 'total': len(_items),
-                'publishable': sum([i.is_publishable() for i in _items])
+                'publishable': sum([i.is_publishable() for i in _items]),
+                'publishable_paths': list({i.path for i in _items if i.is_publishable()})
             }
 
         from collections import OrderedDict
@@ -134,7 +135,7 @@ class Reporter(object):
                 nb=pluralize('defect', cls_stats['publishable'])
             ))
             if 'analyzer' in part:
-                analyzers.append(part['analyzer'])
+                analyzers.append(part['analyzer'].format(files=' '.join(cls_stats['publishable_paths'])))
 
         # Build top comment
         nb = len(issues)

--- a/src/staticanalysis/bot/tests/conftest.py
+++ b/src/staticanalysis/bot/tests/conftest.py
@@ -115,6 +115,7 @@ def mock_issues():
     class MockIssue(object):
         def __init__(self, nb):
             self.nb = nb
+            self.path = '/path/to/file'
 
         def as_markdown(self):
             return 'This is the mock issue n°{}'.format(self.nb)

--- a/src/staticanalysis/bot/tests/test_reporter_mail.py
+++ b/src/staticanalysis/bot/tests/test_reporter_mail.py
@@ -119,5 +119,6 @@ def test_mail(mock_config, mock_issues, mock_phabricator):
         mock_cls: {
             'total': 5,
             'publishable': 3,
+            'publishable_paths': ['/path/to/file']
         }
     }

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -16,7 +16,7 @@ Code analysis found 1 defect in this patch:
  - 1 defect found by clang-tidy
 
 You can run this analysis locally with:
- - `./mach static-analysis check path/to/file.cpp` (C/C++)
+ - `./mach static-analysis check another_test.cpp` (C/C++)
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
 '''  # noqa
@@ -26,7 +26,7 @@ Code analysis found 1 defect in this patch:
  - 1 defect found by clang-format
 
 You can run this analysis locally with:
- - `./mach clang-format -s -p path/to/file.cpp` (C/C++)
+ - `./mach clang-format -s -p dom/test.cpp` (C/C++)
 
 For your convenience, [here is a patch]({results}/clang-format-PHID-DIFF-abcdef.diff) that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply`).
 
@@ -85,11 +85,11 @@ def test_phabricator_clang_tidy(mock_repository, mock_phabricator):
         revision = PhabricatorRevision(api, 'PHID-DIFF-abcdef')
         revision.lines = {
             # Add dummy lines diff
-            'test.cpp': [41, 42, 43],
+            'another_test.cpp': [41, 42, 43],
         }
         reporter = PhabricatorReporter({'analyzers': ['clang-tidy'], 'modes': ('comment')}, api=api)
 
-    issue = ClangTidyIssue(revision, 'test.cpp', '42', '51', 'modernize-use-nullptr', 'dummy message', 'error')
+    issue = ClangTidyIssue(revision, 'another_test.cpp', '42', '51', 'modernize-use-nullptr', 'dummy message', 'error')
     assert issue.is_publishable()
 
     issues, patches = reporter.publish([issue, ], revision)


### PR DESCRIPTION
As per [this](https://bugzilla.mozilla.org/show_bug.cgi?id=1530698) we should provide actionable info for clang-tidy and clang-format.