### PR TITLE
staticanalysis/bot: Fix clang-format bug when no touched/added line in patch

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/clang/format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/format.py
@@ -107,8 +107,9 @@ class ClangFormat(DefaultAnalyzer):
         # Build `ClangFormatIssue`s
         issues = []
         for filename, diff in patch.items():
-            lines = sorted(diff.get('touched', []) + diff.get('added', []))
+            lines = sorted(diff.get('touched', []) + diff.get('added', []) + diff.get('deleted', []))
             if not lines:
+                logger.warn('No modified lines on this file', file=filename)
                 continue
 
             # Group consecutive lines together (algorithm by calixte)

--- a/src/staticanalysis/bot/static_analysis_bot/clang/format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/format.py
@@ -108,9 +108,7 @@ class ClangFormat(DefaultAnalyzer):
         issues = []
         for filename, diff in patch.items():
             lines = sorted(diff.get('touched', []) + diff.get('added', []) + diff.get('deleted', []))
-            if not lines:
-                logger.warn('No modified lines on this file', file=filename)
-                continue
+            assert len(lines) > 0, 'No modified lines on {}'.format(filename)
 
             # Group consecutive lines together (algorithm by calixte)
             groups = []

--- a/src/staticanalysis/bot/static_analysis_bot/clang/format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/format.py
@@ -108,6 +108,8 @@ class ClangFormat(DefaultAnalyzer):
         issues = []
         for filename, diff in patch.items():
             lines = sorted(diff.get('touched', []) + diff.get('added', []))
+            if not lines:
+                continue
 
             # Group consecutive lines together (algorithm by calixte)
             groups = []

--- a/src/staticanalysis/bot/tests/test_clang.py
+++ b/src/staticanalysis/bot/tests/test_clang.py
@@ -102,7 +102,7 @@ def test_clang_format(mock_config, mock_repository, mock_stats, mock_clang, mock
 
     assert issue.path == 'dom/bad.cpp'
     assert issue.line == 2
-    assert issue.nb_lines == 2
+    assert issue.nb_lines == 3
 
     # At the end of the process, original file is patched
     assert open(bad_file).read() == BAD_CPP_VALID


### PR DESCRIPTION
Fix [this bug](https://tools.taskcluster.net/groups/MQmu293iSrWf8d52Fxr7UQ/tasks/MQmu293iSrWf8d52Fxr7UQ/runs/0/logs/public%2Flogs%2Flive.log)