### PR TITLE
Fixes to run code review in shadow mode for Try

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/__init__.py
@@ -203,5 +203,6 @@ class Reliability(enum.Enum):
     Medium = 'medium'
     Low = 'low'
 
+
 # Create common stats instance
 stats = Datadog()

--- a/src/staticanalysis/bot/static_analysis_bot/clang/tidy.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/tidy.py
@@ -433,7 +433,7 @@ class ClangTidyTask(AnalysisTask):
                 char=warning['column'],
                 check=warning['flag'],
                 message=warning['message'],
-                reliability=Reliability(warning['reliability'])
+                reliability=Reliability(warning['reliability']) if 'reliability' in warning else Reliability.Unknown
             )
             for artifact in artifacts.values()
             for path, items in artifact['files'].items()

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -63,7 +63,7 @@ def main(id,
                           existing={
                               'APP_CHANNEL': 'development',
                               'REPORTERS': [],
-                              'ANALYZERS': ['clang-tidy', ],
+                              'ANALYZERS': [],
                               'PUBLICATION': 'IN_PATCH',
                               'ALLOWED_PATHS': ['*', ],
                               'MAX_CLONE_RUNTIME': 15 * 60,

--- a/src/staticanalysis/bot/static_analysis_bot/workflows/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflows/base.py
@@ -34,8 +34,6 @@ class Workflow(object):
     '''
     def __init__(self, reporters, analyzers, index_service, queue_service, phabricator_api):
         assert isinstance(analyzers, list)
-        assert len(analyzers) > 0, \
-            'No analyzers specified, will not run.'
         self.analyzers = analyzers
         assert 'MOZCONFIG' in os.environ, \
             'Missing MOZCONFIG in environment'
@@ -76,10 +74,10 @@ class Workflow(object):
             remote = RemoteWorkflow(self.queue_service)
             issues += remote.run(revision)
 
-        # Always use local workflow
-        # until we have all analyzers in-tree
-        local = LocalWorkflow(self, self.analyzers, self.index_service)
-        issues += local.run(revision)
+        # Use local when some analyzers are set
+        if len(self.analyzers) > 0:
+            local = LocalWorkflow(self, self.analyzers, self.index_service)
+            issues += local.run(revision)
 
         if not issues:
             logger.info('No issues, stopping there.')

--- a/src/staticanalysis/bot/static_analysis_bot/workflows/remote.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflows/remote.py
@@ -6,9 +6,9 @@
 from cli_common.log import get_logger
 from static_analysis_bot.clang.format import ClangFormatTask
 from static_analysis_bot.clang.tidy import ClangTidyTask
-from static_analysis_bot.coverity.coverity import CoverityTask
 from static_analysis_bot.config import SOURCE_TRY
 from static_analysis_bot.config import settings
+from static_analysis_bot.coverity.coverity import CoverityTask
 from static_analysis_bot.infer.infer import InferTask
 from static_analysis_bot.lint import MozLintTask
 

--- a/src/staticanalysis/bot/tests/test_remote.py
+++ b/src/staticanalysis/bot/tests/test_remote.py
@@ -455,6 +455,14 @@ def test_clang_tidy_task(mock_try_config, mock_revision):
                                     'reliability': 'high',
                                     'message': 'some hard issue with c++',
                                     'filename': 'test.cpp',
+                                },
+                                {
+                                    'column': 51,
+                                    'line': 987,
+                                    'flag': 'checker.YYY',
+                                    # No reliability !
+                                    'message': 'some harder issue with c++',
+                                    'filename': 'test.cpp',
                                 }
                             ]
                         }
@@ -465,7 +473,7 @@ def test_clang_tidy_task(mock_try_config, mock_revision):
     }
     workflow = RemoteWorkflow(MockQueue(tasks))
     issues = workflow.run(mock_revision)
-    assert len(issues) == 1
+    assert len(issues) == 2
     issue = issues[0]
     assert isinstance(issue, ClangTidyIssue)
     assert issue.path == 'test.cpp'
@@ -474,6 +482,15 @@ def test_clang_tidy_task(mock_try_config, mock_revision):
     assert issue.check == 'checker.XXX'
     assert issue.reliability == Reliability.High
     assert issue.message == 'some hard issue with c++'
+
+    issue = issues[1]
+    assert isinstance(issue, ClangTidyIssue)
+    assert issue.path == 'test.cpp'
+    assert issue.line == 987
+    assert issue.char == 51
+    assert issue.check == 'checker.YYY'
+    assert issue.reliability == Reliability.Unknown
+    assert issue.message == 'some harder issue with c++'
 
 
 def test_clang_format_task(mock_try_config, mock_revision):


### PR DESCRIPTION
Modifications that should be in a few different PRs:
1. Only run SA local workflow when analyzers are set (i only want the remote workflow !)
2. Use the build target phid instead of the diff phid in the `try_task_config.json` when pushing to try
3. Use that same build target phid in the code review publication task to retrieve the infos from the diff (instead of doing the opposite)
4. Fix a bug in `ClangTidyIssue` building when reliability is not available on remote output