### PR TITLE
pulselistener: Add option to disable treeherder link publication

### DIFF
--- a/src/pulselistener/pulselistener/listener.py
+++ b/src/pulselistener/pulselistener/listener.py
@@ -352,6 +352,7 @@ class PulseListener(object):
                 repo_url=REPO_UNIFIED,
                 repo_dir=os.path.join(cache_root, 'sa-unified'),
                 batch_size=mercurial_conf.get('batch_size', 100000),
+                publish_treeherder_link=mercurial_conf.get('publish_treeherder_link', False),
             )
         else:
             self.mercurial = None

--- a/src/pulselistener/pulselistener/mercurial.py
+++ b/src/pulselistener/pulselistener/mercurial.py
@@ -26,11 +26,13 @@ class MercurialWorker(object):
     '''
     Mercurial worker maintaining a local clone of mozilla-unified
     '''
-    def __init__(self, phabricator_api, ssh_user, ssh_key, repo_url, repo_dir, batch_size):
+    def __init__(self, phabricator_api, ssh_user, ssh_key, repo_url, repo_dir, batch_size, publish_treeherder_link):
         self.repo_url = repo_url
         self.repo_dir = repo_dir
         self.phabricator_api = phabricator_api
         self.batch_size = batch_size
+        self.publish_treeherder_link = publish_treeherder_link
+        logger.info('Treeherder link publication is {}'.format(self.publish_treeherder_link and 'enabled' or 'disabled'))  # noqa
 
         # Build asyncio shared queue
         self.queue = asyncio.Queue()
@@ -193,6 +195,6 @@ class MercurialWorker(object):
         logger.info('Diff has been pushed !')
 
         # Publish Treeherder link
-        if build_target_phid:
+        if build_target_phid and self.publish_treeherder_link:
             uri = TREEHERDER_URL.format(commit.node.decode('utf-8'))
             self.phabricator_api.create_harbormaster_uri(build_target_phid, 'treeherder', 'Treeherder Jobs', uri)

--- a/src/pulselistener/tests/mocks/phabricator/artifact-PHID-HMBT-somehash.json
+++ b/src/pulselistener/tests/mocks/phabricator/artifact-PHID-HMBT-somehash.json
@@ -1,0 +1,9 @@
+{
+  "result": {
+    "data": {
+      "state": "ok"
+    }
+  },
+  "error_code": null,
+  "error_info": null
+}


### PR DESCRIPTION
I forgot to add that option before the release.