### PR TITLE
update pypi2nix

### DIFF
--- a/nix/tools/pypi2nix.json
+++ b/nix/tools/pypi2nix.json
@@ -1,6 +1,6 @@
 {
   "owner": "garbas",
   "repo": "pypi2nix",
-  "rev": "9f7db2df2ab55d7d38b8c68cec677c11a87587e8",
-  "sha256": "0z3821d8hlswlbjc8lrcywzwii0cw2gkj1is46d7lblgcxsdbga2"
+  "rev": "ff1ba9006839fd46e4b237d2757be5b22d408565",
+  "sha256": "0l4ywjn0lb53519m2155r6sfcrlkpx6pnha54kmsqd45pv6lz0rv"
 }


### PR DESCRIPTION
pypi2nix has been failing for a while with "black not found" error
message. The latest revision fixes the issue.