### PR TITLE
staticanalysis/bot: Clean coverity paths in remote issues.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/coverity/coverity.py
@@ -391,7 +391,7 @@ class CoverityTask(AnalysisTask):
             CoverityIssue(
                 revision,
                 issue=warning,
-                file_path=path
+                file_path=self.clean_path(path)
             )
             for artifact in artifacts.values()
             for path, items in artifact['files'].items()

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -144,6 +144,11 @@ class PhabricatorReporter(Reporter):
         assert isinstance(revision, PhabricatorRevision)
         assert isinstance(issue, Issue)
 
+        # Enforce path validation or Phabricator will crash here
+        if not revision.has_file(issue.path):
+            logger.warn('Will not publish inline comment on invalid path {}: {}'.format(issue.path, issue))
+            return
+
         # Check if comment is already posted
         comment = {
             'diffID': revision.diff_id,

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -87,6 +87,7 @@ def test_phabricator_clang_tidy(mock_repository, mock_phabricator):
             # Add dummy lines diff
             'another_test.cpp': [41, 42, 43],
         }
+        revision.files = ['another_test.cpp']
         reporter = PhabricatorReporter({'analyzers': ['clang-tidy'], 'modes': ('comment')}, api=api)
 
     issue = ClangTidyIssue(revision, 'another_test.cpp', '42', '51', 'modernize-use-nullptr', 'dummy message', 'error')
@@ -280,6 +281,7 @@ def test_phabricator_clang_tidy_and_coverage(mock_config, mock_repository, mock_
             'test.cpp': [0],
             'another_test.cpp': [41, 42, 43],
         }
+        revision.files = ['test.txt', 'test.cpp', 'another_test.cpp']
         reporter = PhabricatorReporter({'analyzers': ['coverage', 'clang-tidy']}, api=api)
 
     issue_clang_tidy = ClangTidyIssue(revision, 'another_test.cpp', '42', '51', 'modernize-use-nullptr', 'dummy message', 'error')


### PR DESCRIPTION
Fixes #2062 