### PR TITLE
staticanalysis/bot: Support empty clang-format patches

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/clang/format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/clang/format.py
@@ -257,7 +257,7 @@ class ClangFormatTask(AnalysisTask):
     def build_patches(self, artifacts):
         artifact = artifacts.get('public/code-review/clang-format.diff')
         if artifact is None:
-            logger.warn('Missing clang-format.diff')
+            logger.warn('Missing or empty clang-format.diff')
             return []
 
         assert isinstance(artifact, bytes), 'clang-format.diff should be bytes'

--- a/src/staticanalysis/bot/static_analysis_bot/task.py
+++ b/src/staticanalysis/bot/static_analysis_bot/task.py
@@ -50,7 +50,14 @@ class AnalysisTask(object):
             logger.info('Load artifact', task_id=self.id, artifact=artifact_name)
             try:
                 artifact = queue_service.getArtifact(self.id, self.run_id, artifact_name)
-                out[artifact_name] = 'response' in artifact and artifact['response'].content or artifact
+
+                if 'response' in artifact:
+                    # When the response's content is empty, set content to None
+                    content = artifact['response'].content or None
+                else:
+                    # Json responses are automatically parsed into Python structures
+                    content = artifact
+                out[artifact_name] = content
             except Exception as e:
                 logger.warn('Failed to read artifact', task_id=self.id, run_id=self.run_id, artifact=artifact_name, error=e)
                 continue


### PR DESCRIPTION
To avoid [this issue](https://tools.taskcluster.net/groups/VVI337njQmKMBDfR7_w8ow/tasks/VVI337njQmKMBDfR7_w8ow/runs/0/logs/public%2Flogs%2Flive.log)