### PR TITLE
Warn developer when we fail to apply its patch

### DIFF
--- a/lib/cli_common/cli_common/phabricator.py
+++ b/lib/cli_common/cli_common/phabricator.py
@@ -130,7 +130,7 @@ class UnitResult(dict):
 
     def validates(self):
         '''
-        Check the input is a lint issue compatible with Phabricator
+        Check the input is a unit result compatible with Phabricator
         '''
         # Check name
         assert isinstance(self['name'], str), 'name should be a string'

--- a/src/pulselistener/pulselistener/cli.py
+++ b/src/pulselistener/pulselistener/cli.py
@@ -25,17 +25,17 @@ from pulselistener.listener import PulseListener
     default=os.path.join(tempfile.gettempdir(), 'pulselistener'),
 )
 @click.option(
-    '--phab-revision',
-    type=int,
+    '--phab-build-target',
+    type=str,
     required=False,
-    help='A Phabricator revision ID to test'
+    help='A Phabricator build target PHID to test'
 )
 @taskcluster_options
 def main(taskcluster_secret,
          taskcluster_client_id,
          taskcluster_access_token,
          cache_root,
-         phab_revision,
+         phab_build_target,
          ):
 
     secrets = get_secrets(taskcluster_secret,
@@ -84,8 +84,8 @@ def main(taskcluster_secret,
                        )
     click.echo('Listening to pulse messages...')
 
-    if phab_revision:
-        pl.add_revision(phab_revision)
+    if phab_build_target:
+        pl.add_build(phab_build_target)
 
     pl.run()
 

--- a/src/pulselistener/pulselistener/listener.py
+++ b/src/pulselistener/pulselistener/listener.py
@@ -116,38 +116,13 @@ class HookPhabricator(Hook):
 
     async def build_consumer(self, *args, **kwargs):
         '''
-        Main consumer:
-        * Query phabricator differentials regularly
-        * Check queued builds
+        Main consumer, running queued builds
         '''
         while True:
+            await self.run_builds()
 
-            # Get new differential ids
-            if self.mode == MODE_PHABRICATOR_POLLING:
-                await self.poll_phabricator()
-
-                # Sleep a bit before trying new diffs
-                await asyncio.sleep(60)
-
-            elif self.mode == MODE_PHABRICATOR_WEBHOOK:
-                await self.run_builds()
-
-                # Sleep just a bit between two runs
-                await asyncio.sleep(2)
-
-    async def poll_phabricator(self):
-        '''
-        Poll Phabricator Diff search endpoint to trigger new tasks
-        '''
-        for diff in self.list_differential():
-            try:
-                # Load revision to get repository
-                rev = self.api.load_revision(diff['revisionPHID'])
-
-                logger.info('Triggering task from polling', diff=diff['id'])
-                await self.trigger_task(diff, rev['fields']['repositoryPHID'])
-            except Exception as e:
-                logger.error('Failed to trigger task from polling', error=str(e))
+            # Sleep just a bit between two runs
+            await asyncio.sleep(2)
 
     async def run_builds(self):
         '''
@@ -159,7 +134,7 @@ class HookPhabricator(Hook):
             if build.state == PhabricatorBuildState.Queued and build.check_visibility(self.api, self.secure_projects):
                 try:
                     logger.info('Triggering task from webhook', build=build)
-                    await self.trigger_task(build.diff, build.repo_phid)
+                    await self.trigger_task(target_phid, build.diff, build.repo_phid)
                     # TODO: better integration with mercurial queue
                     # to get the revisions produced
                 except Exception as e:
@@ -200,7 +175,7 @@ class HookPhabricator(Hook):
         logger.info('Queued new build', build=build)
         return web.Response(text='Build queued')
 
-    async def trigger_task(self, diff, repo_phid):
+    async def trigger_task(self, build_target_phid, diff, repo_phid):
         '''
         Trigger a code review task using configured modes: Try or Taskcluster
         '''
@@ -218,7 +193,7 @@ class HookPhabricator(Hook):
             await self.create_task({
                 'ANALYSIS_SOURCE': 'phabricator',
                 'ANALYSIS_ID': diff['phid'],
-                'HARBORMASTER_TARGET': diff.get('build_target_phid'),
+                'HARBORMASTER_TARGET': build_target_phid,
             })
         else:
             logger.info('Skipping Taskcluster task', diff=diff['phid'])
@@ -227,7 +202,7 @@ class HookPhabricator(Hook):
         if ACTION_TRY in self.actions:
             assert self.mercurial_queue is not None, \
                 'No mercurial queue to push on try!'
-            await self.mercurial_queue.put(diff)
+            await self.mercurial_queue.put((build_target_phid, diff))
         else:
             logger.info('Skipping Try job', diff=diff['phid'])
 

--- a/src/pulselistener/pulselistener/mercurial.py
+++ b/src/pulselistener/pulselistener/mercurial.py
@@ -118,9 +118,9 @@ class MercurialWorker(object):
             # Report generic failure as a Unit Test issue
             failure = UnitResult(
                 namespace='code-review',
-                name='mercurial',
+                name='general',
                 result=UnitResultState.Broken,
-                details='WARNING: An error occured in the code review bot when applying your patch.\n\n```{}```'.format(e),
+                details='WARNING: An error occured in the code review bot.\n\n```{}```'.format(e),
                 format='remarkup',
                 duration=time.time() - start,
             )

--- a/src/pulselistener/pulselistener/phabricator.py
+++ b/src/pulselistener/pulselistener/phabricator.py
@@ -79,9 +79,6 @@ class PhabricatorBuild(object):
             if not diffs:
                 raise Exception('Diff not found')
             self.diff = diffs[0]
-
-            # Add target to diff for treeherder link publication
-            self.diff['build_target_phid'] = self.target_phid
         except Exception as e:
             logger.info('Revision not accessible', build=str(self), error=str(e))
 

--- a/src/pulselistener/tests/mocks/phabricator/message-PHID-somehash-fail-unit.json
+++ b/src/pulselistener/tests/mocks/phabricator/message-PHID-somehash-fail-unit.json
@@ -1,0 +1,10 @@
+{
+    "result": {
+      "type": "fail",
+      "buildTargetPHID": "PHID-somehash",
+      "unit": [],
+      "lint": []
+    },
+    "error_code": null,
+    "error_info": null
+}

--- a/src/pulselistener/tests/test_mercurial.py
+++ b/src/pulselistener/tests/test_mercurial.py
@@ -32,7 +32,7 @@ async def test_push_to_try(PhabricatorMock, RepoMock):
             repo_url='http://mozilla-central',
             repo_dir=repo_dir,
             batch_size=100,
-            publish_treeherder_link=False,
+            publish_phabricator=False,
         )
         worker.repo = RepoMock
 
@@ -123,7 +123,7 @@ async def test_push_to_try_existing_rev(PhabricatorMock, RepoMock):
             repo_url='http://mozilla-central',
             repo_dir=repo_dir,
             batch_size=100,
-            publish_treeherder_link=False,
+            publish_phabricator=False,
         )
         worker.repo = RepoMock
 
@@ -213,7 +213,7 @@ async def test_treeherder_link(PhabricatorMock, RepoMock):
             repo_url='http://mozilla-central',
             repo_dir=repo_dir,
             batch_size=100,
-            publish_treeherder_link=True,
+            publish_phabricator=True,
         )
         worker.repo = RepoMock
 
@@ -258,7 +258,7 @@ async def test_failure(PhabricatorMock, RepoMock):
             repo_url='http://mozilla-central',
             repo_dir=repo_dir,
             batch_size=100,
-            publish_treeherder_link=True,
+            publish_phabricator=True,
         )
         worker.repo = RepoMock
 

--- a/src/pulselistener/tests/test_mercurial.py
+++ b/src/pulselistener/tests/test_mercurial.py
@@ -35,14 +35,15 @@ async def test_push_to_try(PhabricatorMock, RepoMock):
         )
         worker.repo = RepoMock
 
-        await worker.handle_diff({
+        diff = {
             'phid': 'PHID-DIFF-test123',
             'revisionPHID': 'PHID-DREV-deadbeef',
             'id': 1234,
 
             # Revision does not exist, will apply on tip
             'baseRevision': 'abcdef12345',
-        })
+        }
+        await worker.handle_diff('PHID-HMBT-deadbeef', diff)
 
         # Check the treeherder link was NOT published
         assert api.mocks.calls[-1].request.url != 'http://phabricator.test/api/harbormaster.createartifact'
@@ -58,7 +59,7 @@ async def test_push_to_try(PhabricatorMock, RepoMock):
         'parameters': {
             'target_tasks_method': 'codereview',
             'optimize_target_tasks': True,
-            'phabricator_diff': 'PHID-DIFF-test123',
+            'phabricator_diff': 'PHID-HMBT-deadbeef',
         }
     }
 
@@ -125,14 +126,15 @@ async def test_push_to_try_existing_rev(PhabricatorMock, RepoMock):
         )
         worker.repo = RepoMock
 
-        await worker.handle_diff({
+        diff = {
             'phid': 'PHID-DIFF-solo',
             'revisionPHID': 'PHID-DREV-solo',
             'id': 9876,
 
             # Revision does not exist, will apply on tip
             'baseRevision': base,
-        })
+        }
+        await worker.handle_diff('PHID-HMBT-deadbeef', diff)
 
         # Check the treeherder link was NOT published
         assert api.mocks.calls[-1].request.url != 'http://phabricator.test/api/harbormaster.createartifact'
@@ -148,7 +150,7 @@ async def test_push_to_try_existing_rev(PhabricatorMock, RepoMock):
         'parameters': {
             'target_tasks_method': 'codereview',
             'optimize_target_tasks': True,
-            'phabricator_diff': 'PHID-DIFF-solo',
+            'phabricator_diff': 'PHID-HMBT-deadbeef',
         }
     }
 
@@ -214,13 +216,13 @@ async def test_treeherder_link(PhabricatorMock, RepoMock):
         )
         worker.repo = RepoMock
 
-        await worker.handle_diff({
+        diff = {
             'phid': 'PHID-DIFF-test123',
             'revisionPHID': 'PHID-DREV-deadbeef',
             'id': 1234,
-            'build_target_phid': 'PHID-HMBT-somehash',
             'baseRevision': 'abcdef12345',
-        })
+        }
+        await worker.handle_diff('PHID-HMBT-somehash', diff)
 
         # Check the treeherder link was published
         assert api.mocks.calls[-1].request.url == 'http://phabricator.test/api/harbormaster.createartifact'

--- a/src/pulselistener/tests/test_mercurial.py
+++ b/src/pulselistener/tests/test_mercurial.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
 import os.path
+import urllib
 
 import pytest
 
@@ -43,7 +44,7 @@ async def test_push_to_try(PhabricatorMock, RepoMock):
             # Revision does not exist, will apply on tip
             'baseRevision': 'abcdef12345',
         }
-        await worker.handle_diff('PHID-HMBT-deadbeef', diff)
+        await worker.push_to_try('PHID-HMBT-deadbeef', diff)
 
         # Check the treeherder link was NOT published
         assert api.mocks.calls[-1].request.url != 'http://phabricator.test/api/harbormaster.createartifact'
@@ -134,7 +135,7 @@ async def test_push_to_try_existing_rev(PhabricatorMock, RepoMock):
             # Revision does not exist, will apply on tip
             'baseRevision': base,
         }
-        await worker.handle_diff('PHID-HMBT-deadbeef', diff)
+        await worker.push_to_try('PHID-HMBT-deadbeef', diff)
 
         # Check the treeherder link was NOT published
         assert api.mocks.calls[-1].request.url != 'http://phabricator.test/api/harbormaster.createartifact'
@@ -222,7 +223,7 @@ async def test_treeherder_link(PhabricatorMock, RepoMock):
             'id': 1234,
             'baseRevision': 'abcdef12345',
         }
-        await worker.handle_diff('PHID-HMBT-somehash', diff)
+        await worker.push_to_try('PHID-HMBT-somehash', diff)
 
         # Check the treeherder link was published
         assert api.mocks.calls[-1].request.url == 'http://phabricator.test/api/harbormaster.createartifact'
@@ -231,3 +232,66 @@ async def test_treeherder_link(PhabricatorMock, RepoMock):
     # Tip should be updated
     tip = RepoMock.tip()
     assert tip.node != initial.node
+
+
+@pytest.mark.asyncio
+async def test_failure(PhabricatorMock, RepoMock):
+    '''
+    Run mercurial worker on a single diff
+    and check the treeherder link publication as an artifact
+    '''
+    # Get initial tip commit in repo
+    initial = RepoMock.tip()
+
+    # The patched and config files should not exist at first
+    repo_dir = RepoMock.root().decode('utf-8')
+    config = os.path.join(repo_dir, 'try_task_config.json')
+    target = os.path.join(repo_dir, 'test.txt')
+    assert not os.path.exists(target)
+    assert not os.path.exists(config)
+
+    with PhabricatorMock as api:
+        worker = MercurialWorker(
+            api,
+            ssh_user='john@doe.com',
+            ssh_key='privateSSHkey',
+            repo_url='http://mozilla-central',
+            repo_dir=repo_dir,
+            batch_size=100,
+            publish_treeherder_link=True,
+        )
+        worker.repo = RepoMock
+
+        diff = {
+            # Missing revisionPHID will give an assertion error
+            'phid': 'PHID-DIFF-test123',
+            'id': 1234,
+        }
+        out = await worker.handle_build('PHID-somehash', diff)
+        assert out is False
+
+        # Check the unit result was published
+        assert api.mocks.calls[-1].request.url == 'http://phabricator.test/api/harbormaster.sendmessage'
+        params = json.loads(urllib.parse.parse_qs(api.mocks.calls[-1].request.body)['params'][0])
+        assert params['unit'][0]['duration'] > 0
+        del params['unit'][0]['duration']
+        assert params == {
+            'buildTargetPHID': 'PHID-somehash',
+            'type': 'fail',
+            'unit': [
+                {
+                    'name': 'mercurial',
+                    'result': 'broken',
+                    'namespace': 'code-review',
+                    'details': 'WARNING: An error occured in the code review bot when applying your patch.\n\n``````',
+                    'format': 'remarkup',
+                }
+            ],
+            'lint': [],
+            '__conduit__': {'token': 'deadbeef'}
+        }
+        assert api.mocks.calls[-1].response.status_code == 200
+
+        # Clone should not be modified
+        tip = RepoMock.tip()
+        assert tip.node == initial.node

--- a/src/pulselistener/tests/test_mercurial.py
+++ b/src/pulselistener/tests/test_mercurial.py
@@ -280,10 +280,10 @@ async def test_failure(PhabricatorMock, RepoMock):
             'type': 'fail',
             'unit': [
                 {
-                    'name': 'mercurial',
+                    'name': 'general',
                     'result': 'broken',
                     'namespace': 'code-review',
-                    'details': 'WARNING: An error occured in the code review bot when applying your patch.\n\n``````',
+                    'details': 'WARNING: An error occured in the code review bot.\n\n``````',
                     'format': 'remarkup',
                 }
             ],


### PR DESCRIPTION
Fixes #1542 by (ab)using Phabricator Unit tests results.

This PR does a bit of cleanup first, by removing the deprecated phabricator polling method. This allows me to require `build_target_phid` since the beginning instead of relying on a key in a dict.

I played a bit with Phabricator options, and [here is the final result](https://phabricator-dev.allizom.org/D1146)