### PR TITLE
tooltool/api: provide client via api

### DIFF
--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -939,6 +939,7 @@ in rec {
           include ${self.dirname}/*.json
           include ${self.dirname}/*.mako
           include ${self.dirname}/*.yml
+          include ${self.dirname}/*.download
 
           recursive-exclude * __pycache__
           recursive-exclude * *.py[co]

--- a/src/tooltool/api/default.nix
+++ b/src/tooltool/api/default.nix
@@ -54,6 +54,10 @@ let
       (fromRequirementsFile ./requirements-dev.txt python.packages);
     propagatedBuildInputs =
       (fromRequirementsFile ./requirements.txt python.packages);
+    prePatch = ''
+      rm -f tooltool_api/tooltool.py.download
+      ln -s ${../client/tooltool.py} tooltool_api/tooltool.py.download
+    '';
     passthru = {
       cron = {
         check_pending_uploads = mkCronJob { schedule = [ "*/10 * * * *" ];  # every 10 min;

--- a/src/tooltool/api/tooltool_api/__init__.py
+++ b/src/tooltool/api/tooltool_api/__init__.py
@@ -53,4 +53,6 @@ def create_app(config: dict = None) -> flask.Flask:
     app.cli.add_command(tooltool_api.cli.cmd_replicate, 'replicate')
     app.cli.add_command(tooltool_api.cli.cmd_check_pending_uploads, 'check-pending-uploads')
 
+    app.add_url_rule('/tooltool.py', view_func=tooltool_api.api.download_client)
+
     return app

--- a/src/tooltool/api/tooltool_api/api.py
+++ b/src/tooltool/api/tooltool_api/api.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import datetime
+import pathlib
 import random
 import typing
 
@@ -306,3 +307,8 @@ def download_file(digest: str, region: typing.Optional[str] = None) -> werkzeug.
     signed_url = s3.generate_url(method='GET', expires_in=DOWLOAD_EXPIRES_IN, bucket=bucket, key=key)
 
     return flask.redirect(signed_url)
+
+
+def download_client():
+    client = pathlib.Path(__file__).parent / 'tooltool.py.download'
+    return flask.send_file(str(client.absolute()), attachment_filename='tooltool.py')

--- a/src/tooltool/api/tooltool_api/tooltool.py.download
+++ b/src/tooltool/api/tooltool_api/tooltool.py.download
@@ -1,0 +1,1 @@
+../../client/tooltool.py


### PR DESCRIPTION
as http://tooltool.mozilla-releng.net/tooltool.py