### PR TITLE
pulselistener: Fix old variable usage

### DIFF
--- a/src/pulselistener/pulselistener/listener.py
+++ b/src/pulselistener/pulselistener/listener.py
@@ -327,7 +327,7 @@ class PulseListener(object):
                 repo_url=REPO_UNIFIED,
                 repo_dir=os.path.join(cache_root, 'sa-unified'),
                 batch_size=mercurial_conf.get('batch_size', 100000),
-                publish_treeherder_link=mercurial_conf.get('publish_treeherder_link', False),
+                publish_phabricator=mercurial_conf.get('publish_phabricator', False),
             )
         else:
             self.mercurial = None


### PR DESCRIPTION
Got a nice dummy crash on staging

[Manual Deployment](https://tools.taskcluster.net/groups/ASC9k9vcRPSOXkYZqnB-og/tasks/ASC9k9vcRPSOXkYZqnB-og/details) on staging for test.