### PR TITLE
staticanalysis/bot: For Coverity analysis when calling is_publishable also use the method defined in the base class.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/tasks/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/coverity.py
@@ -83,18 +83,6 @@ class CoverityIssue(Issue):
             'line': self.line,
         }
 
-    def is_publishable(self):
-        '''
-        We don't use the default `is_publishable` implementation from `Issue`
-        because for CoverityIssue we don't apply the same logic to filter issues
-        as we do with the rest of our Analyzers, for IN_PATCH or BEFORE_AFTER methods,
-        since Coverity performs most of the checks on the servers and provides us a
-        snapshot with the checks that can be filtered only by the is_local function.
-        Coverity also has the ability to forward clang errors but we don't want to forward
-        these errors to the review.
-        '''
-        return not self.is_clang_error() and self.is_local()
-
     def is_clang_error(self):
         '''
         Determine if the current issue is a translation unit error forwarded by Clang
@@ -116,7 +104,7 @@ class CoverityIssue(Issue):
         '''
         Publish only local Coverity issues
         '''
-        return self.is_local()
+        return self.is_local() and not self.is_clang_error()
 
     def as_text(self):
         '''

--- a/src/staticanalysis/bot/tests/test_coverity.py
+++ b/src/staticanalysis/bot/tests/test_coverity.py
@@ -86,7 +86,7 @@ The path that leads to this defect is:
     assert issue.nb_lines == 1
 
     assert issue.validates()
-    assert issue.is_publishable()
+    assert not issue.is_publishable()
 
     assert issue.as_text() == '''Checker reliability (false positive risk) is medium.
 Dereferencing a pointer that might be "nullptr" "env" when calling "lookupImport".
@@ -124,7 +124,7 @@ The path that leads to this defect is:
 ''',
         'nb_lines': 1,
         'path': 'js/src/jit/BaselineCompiler.cpp',
-        'publishable': True,
+        'publishable': False,
         'reliability': 'medium',
         'validates': True,
         'validation': {


### PR DESCRIPTION
In order to avoid bugs like [this](https://bugzilla.mozilla.org/show_bug.cgi?id=1542163) we should also call the base method of ```is_publishable```.