### PR TITLE
staticanalysis/bot: Change the wording for `reliability` index in order to make less prone to confusion.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/tasks/clang_tidy.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/clang_tidy.py
@@ -29,7 +29,7 @@ ISSUE_MARKDOWN = '''
 - **Expanded Macro**: {expanded_macro}
 - **Publishable **: {publishable}
 - **Is new**: {is_new}
-- **Checker reliability (false positive risk)**: {reliability}
+- **Checker reliability **: {reliability} (false positive risk)
 
 ```
 {body}
@@ -143,7 +143,7 @@ class ClangTidyIssue(Issue):
             body += '\n{}'.format(self.reason)
         # Also add the reliability of the checker
         if self.reliability != Reliability.Unknown:
-            body += '\nChecker reliability (false positive risk) is {}.'.format(self.reliability.value)
+            body += '\nChecker reliability is {} (false positive risk).'.format(self.reliability.value)
         return body
 
     def as_markdown(self):
@@ -206,7 +206,7 @@ class ClangTidyIssue(Issue):
 
         # Append to description the reliability index if any
         if self.reliability != Reliability.Unknown:
-            description += '\nChecker reliability (false positive risk) is {}.'.format(self.reliability.value)
+            description += '\nChecker reliability is {} (false positive risk).'.format(self.reliability.value)
 
         if self.body:
             description += '\n\n > {}'.format(self.body)

--- a/src/staticanalysis/bot/static_analysis_bot/tasks/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/coverity.py
@@ -22,7 +22,7 @@ ISSUE_MARKDOWN = '''
 - **Publishable **: {publishable}
 - **Is Clang Error**: {is_clang_error}
 - **Is Local**: {is_local}
-- **Reliability**: {reliability}
+- **Reliability**: {reliability} (false positive risk)
 
 ```
 {body}
@@ -111,7 +111,7 @@ class CoverityIssue(Issue):
         Build the text body published on reporters
         '''
         # If there is the reliability index use it
-        return f'Checker reliability (false positive risk) is {self.reliability.value}.\n{self.message}' \
+        return f'Checker reliability is {self.reliability.value} (false positive risk).\n{self.message}' \
             if self.reliability != Reliability.Unknown \
             else self.message
 
@@ -157,7 +157,7 @@ class CoverityIssue(Issue):
         Outputs a Phabricator lint result
         '''
         # If there is the reliability index use it
-        message = f'Checker reliability (false positive risk) is {self.reliability.value}.\n{self.message}' \
+        message = f'Checker reliability is {self.reliability.value} (false positive risk).\n{self.message}' \
             if self.reliability != Reliability.Unknown \
             else self.message
 

--- a/src/staticanalysis/bot/tests/test_clang.py
+++ b/src/staticanalysis/bot/tests/test_clang.py
@@ -92,7 +92,7 @@ def test_as_markdown(mock_revision):
 - **Expanded Macro**: no
 - **Publishable **: no
 - **Is new**: no
-- **Checker reliability (false positive risk)**: high
+- **Checker reliability **: high (false positive risk)
 
 ```
 Dummy body
@@ -105,7 +105,7 @@ Dummy body
         'code': 'clang-tidy.dummy-check',
         'line': 42,
         'name': 'Clang-Tidy - dummy-check',
-        'description': 'dummy message\nChecker reliability (false positive risk) is high.\n\n > Dummy body',
+        'description': 'dummy message\nChecker reliability is high (false positive risk).\n\n > Dummy body',
         'path': 'test.cpp',
         'severity': 'warning',
     }

--- a/src/staticanalysis/bot/tests/test_coverity.py
+++ b/src/staticanalysis/bot/tests/test_coverity.py
@@ -88,7 +88,7 @@ The path that leads to this defect is:
     assert issue.validates()
     assert not issue.is_publishable()
 
-    assert issue.as_text() == '''Checker reliability (false positive risk) is medium.
+    assert issue.as_text() == '''Checker reliability is medium (false positive risk).
 Dereferencing a pointer that might be "nullptr" "env" when calling "lookupImport".
 The path that leads to this defect is:
 

--- a/src/staticanalysis/bot/tests/test_remote.py
+++ b/src/staticanalysis/bot/tests/test_remote.py
@@ -565,7 +565,7 @@ def test_coverity_task(mock_config, mock_revision, mock_workflow):
     assert issue.is_local()
     assert not issue.is_clang_error()
     assert issue.validates()
-    assert issue.as_text() == f'Checker reliability (false positive risk) is high.\nSome error here'
+    assert issue.as_text() == f'Checker reliability is high (false positive risk).\nSome error here'
 
     # Testing will coverity full stack support
     mock_config.cov_full_stack = True


### PR DESCRIPTION
Right now the message is a little bit confusing, since it leads the developer to believe that a `low` index refers to a low probability of the checker having `false-positives`.