### PR TITLE
staticanalysis/bot: Cleanup Coverity data that was used for local analysis. Fixes #2082

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -63,7 +63,6 @@ def main(taskcluster_secret,
         secrets['APP_CHANNEL'],
         secrets['PUBLICATION'],
         secrets['ALLOWED_PATHS'],
-        secrets.get('COVERITY_CONFIG'),
     )
     # Setup statistics
     datadog_api_key = secrets.get('DATADOG_API_KEY')

--- a/src/staticanalysis/bot/static_analysis_bot/config.py
+++ b/src/staticanalysis/bot/static_analysis_bot/config.py
@@ -44,19 +44,10 @@ class Settings(object):
         self.try_task_id = None
         self.try_group_id = None
 
-        # For Coverity Analysis package info
-        self.cov_analysis_url = None
-        self.cov_package_name = None
-        self.cov_package_ver = None
-        self.cov_url = None
-        self.cov_auth = None
-        self.cov_full_stack = False
-
     def setup(self,
               app_channel,
               publication,
               allowed_paths,
-              cov_config=None,
               ):
         # Detect source from env
         if 'TRY_TASK_ID' in os.environ and 'TRY_TASK_GROUP_ID' in os.environ:
@@ -94,15 +85,6 @@ class Settings(object):
         assert isinstance(allowed_paths, list)
         assert all(map(lambda p: isinstance(p, str), allowed_paths))
         self.allowed_paths = allowed_paths
-
-        # Set different info for Coverity
-        if cov_config is not None:
-            self.cov_analysis_url = cov_config.get('package_url')
-            self.cov_package_name = cov_config.get('package_name')
-            self.cov_url = cov_config.get('server_url')
-            self.cov_auth = cov_config.get('auth_key')
-            self.cov_package_ver = cov_config.get('package_ver')
-            self.cov_full_stack = cov_config.get('full_stack', False)
 
     def __getattr__(self, key):
         if key not in self.config:

--- a/src/staticanalysis/bot/static_analysis_bot/tasks/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/coverity.py
@@ -8,7 +8,6 @@ from cli_common.phabricator import LintResult
 from static_analysis_bot import COVERITY
 from static_analysis_bot import Issue
 from static_analysis_bot import Reliability
-from static_analysis_bot.config import settings
 from static_analysis_bot.tasks.base import AnalysisTask
 
 logger = get_logger(__name__)
@@ -55,17 +54,16 @@ class CoverityIssue(Issue):
         self.message = issue['message']
 
         self.state_on_server = issue['extra']['stateOnServer']
-        if settings.cov_full_stack:
+        # If we have `stack` in the `try` result then embed it in the message.
+        if 'stack' in issue['extra']:
             self.message += ISSUE_RELATION
-            # Embed all events into message
-            if 'stack' in issue['extra']:
-                stack = issue['extra']['stack']
-                for event in stack:
-                    self.message += ISSUE_ELEMENT_IN_STACK.format(
-                        file_path=event['file_path'],
-                        line_number=event['line_number'],
-                        path_type=event['path_type'],
-                        description=event['description'])
+            stack = issue['extra']['stack']
+            for event in stack:
+                self.message += ISSUE_ELEMENT_IN_STACK.format(
+                    file_path=event['file_path'],
+                    line_number=event['line_number'],
+                    path_type=event['path_type'],
+                    description=event['description'])
 
         self.body = None
         self.nb_lines = 1

--- a/src/staticanalysis/bot/tests/test_coverity.py
+++ b/src/staticanalysis/bot/tests/test_coverity.py
@@ -31,16 +31,11 @@ def test_simple(mock_revision, mock_config):
     '''
     Test parsing a simple Coverity artifact
     '''
-    assert mock_config.cov_full_stack is False
-    mock_config.cov_full_stack = True
 
     task = MockCoverityTask()
     issues = task.parse_issues(mock_coverity('simple'), mock_revision)
     assert len(issues) == 1
     assert all(map(lambda i: isinstance(i, CoverityIssue), issues))
-
-    # Revert value to avoid side effects on other tests
-    mock_config.cov_full_stack = False
 
     issue = issues[0]
 

--- a/src/staticanalysis/bot/tests/test_remote.py
+++ b/src/staticanalysis/bot/tests/test_remote.py
@@ -549,7 +549,11 @@ def test_coverity_task(mock_config, mock_revision, mock_workflow):
     assert issue.kind == 'UNINIT'
     assert issue.reliability == Reliability.High
     assert issue.bug_type == 'Memory - corruptions'
-    assert issue.message == 'Using uninitialized value \"a\".'
+    assert issue.message == '''Using uninitialized value "a".
+The path that leads to this defect is:
+
+- //dom/animation/Animation.cpp:61//:
+-- `path: Condition \"!target.oper…", taking false branch.`.\n'''
     assert issue.is_local()
     assert not issue.is_clang_error()
     assert issue.validates()
@@ -566,16 +570,6 @@ def test_coverity_task(mock_config, mock_revision, mock_workflow):
     assert not issue.is_clang_error()
     assert issue.validates()
     assert issue.as_text() == f'Checker reliability (false positive risk) is high.\nSome error here'
-
-    # Testing will coverity full stack support
-    mock_config.cov_full_stack = True
-    issues = mock_workflow.run(mock_revision)
-    issue = issues[0]
-    assert issue.message == '''Using uninitialized value "a".
-The path that leads to this defect is:
-
-- //dom/animation/Animation.cpp:61//:
--- `path: Condition \"!target.oper…", taking false branch.`.\n'''
 
 
 def test_infer_task(mock_config, mock_revision, mock_workflow):


### PR DESCRIPTION
Since we are no longer using local analysis for `Coverity` we should remove the rest of the references.