### PR TITLE
staticanalysis/bot: Append diff-id to the linting messages.

### DIFF
--- a/src/staticanalysis/bot/static_analysis_bot/report/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/base.py
@@ -33,7 +33,7 @@ COMMENT_PARTS = {
     },
 }
 COMMENT_FAILURE = '''
-Code analysis found {defects_total} in this patch{extras_comments}:
+Code analysis found {defects_total} in this diff n°{diff_id}{extras_comments}:
 {defects}
 '''
 COMMENT_RUN_ANALYZERS = '''
@@ -113,7 +113,7 @@ class Reporter(object):
             for cls, items in groups
         ])
 
-    def build_comment(self, issues, bug_report_url, patches=[]):
+    def build_comment(self, revision, issues, bug_report_url, patches=[]):
         '''
         Build a Markdown comment about published issues
         '''
@@ -144,6 +144,7 @@ class Reporter(object):
         comment = COMMENT_FAILURE.format(
             extras_comments=extras,
             defects_total=pluralize('defect', nb),
+            diff_id=revision.diff_id,
             defects='\n'.join(defects),
         )
 

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -105,6 +105,7 @@ class PhabricatorReporter(Reporter):
             self.api.comment(
                 revision.id,
                 self.build_comment(
+                    revision=revision,
                     issues=non_coverage_issues,
                     patches=patches,
                     bug_report_url=BUG_REPORT_URL,

--- a/src/staticanalysis/bot/tests/test_reporter_phabricator.py
+++ b/src/staticanalysis/bot/tests/test_reporter_phabricator.py
@@ -11,7 +11,7 @@ import pytest
 import responses
 
 VALID_CLANG_TIDY_MESSAGE = '''
-Code analysis found 1 defect in this patch:
+Code analysis found 1 defect in this diff n°42:
  - 1 defect found by clang-tidy
 
 You can run this analysis locally with:
@@ -21,7 +21,7 @@ If you see a problem in this automated review, [please report it here](https://b
 '''  # noqa
 
 VALID_CLANG_FORMAT_MESSAGE = '''
-Code analysis found 1 defect in this patch:
+Code analysis found 1 defect in this diff n°42:
  - 1 defect found by clang-format
 
 You can run this analysis locally with:


### PR DESCRIPTION
In order to make defects more tighten to the diff id we should also publish the diff id near the defects summary for each analyser. 