### PR TITLE
cli_common: Do not remove bucket from service account secret.

### DIFF
--- a/lib/cli_common/cli_common/gcp.py
+++ b/lib/cli_common/cli_common/gcp.py
@@ -13,7 +13,7 @@ def get_bucket(service_account):
     # Load credentials from Taskcluster secret
     if 'bucket' not in service_account:
         raise KeyError('Missing bucket in GOOGLE_CLOUD_STORAGE')
-    bucket = service_account.pop('bucket')
+    bucket = service_account['bucket']
 
     # Use those credentials to create a Storage client
     # The project is needed to avoid checking env variables and crashing


### PR DESCRIPTION
Fix for the backend issue:

```
{
    "detail": "'Missing bucket in GOOGLE_CLOUD_STORAGE'",
    "instance": "about:blank",
    "status": 500,
    "title": "'Missing bucket in GOOGLE_CLOUD_STORAGE'",
    "type": "about:blank"
}
```