### PR TITLE
Use structlog & logbook

### DIFF
--- a/src/staticanalysis/bot/requirements.nix
+++ b/src/staticanalysis/bot/requirements.nix
@@ -917,32 +917,6 @@ let
       };
     };
 
-    "mozilla-cli-common" = python.mkDerivation {
-      name = "mozilla-cli-common-1.0.0";
-      src = pkgs.lib.cleanSource ./../../../lib/cli_common;
-      doCheck = commonDoCheck;
-      checkPhase = "";
-      installCheckPhase = "";
-      buildInputs = commonBuildInputs ++ [ ];
-      propagatedBuildInputs = [
-        self."Click"
-        self."Logbook"
-        self."aioamqp"
-        self."mozdef-client"
-        self."python-dateutil"
-        self."python-hglib"
-        self."raven"
-        self."requests"
-        self."structlog"
-        self."taskcluster"
-      ];
-      meta = with pkgs.stdenv.lib; {
-        homepage = "https://github.com/mozilla/release-services";
-        license = licenses.mpl20;
-        description = "Services behind https://mozilla-releng.net";
-      };
-    };
-
     "multidict" = python.mkDerivation {
       name = "multidict-4.5.2";
       src = pkgs.fetchurl {

--- a/src/staticanalysis/bot/requirements.txt
+++ b/src/staticanalysis/bot/requirements.txt
@@ -1,7 +1,9 @@
--e ./../../../lib/cli_common[log,pulse,mercurial] #egg=mozilla-cli-common
+-e ./../../../lib/cli_common[pulse,mercurial] #egg=mozilla-cli-common
 
 parsepatch
 datadog
 libmozdata>=0.1.55
 toml
 taskcluster
+Logbook
+structlog

--- a/src/staticanalysis/bot/requirements.txt
+++ b/src/staticanalysis/bot/requirements.txt
@@ -1,5 +1,3 @@
--e ./../../../lib/cli_common[pulse,mercurial] #egg=mozilla-cli-common
-
 parsepatch
 datadog
 libmozdata>=0.1.55

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -6,11 +6,10 @@
 import argparse
 import os
 
+import structlog
 from libmozdata.phabricator import BuildState
 from libmozdata.phabricator import PhabricatorAPI
 
-from cli_common.log import get_logger
-from cli_common.log import init_logger
 from static_analysis_bot import AnalysisException
 from static_analysis_bot import config
 from static_analysis_bot import stats
@@ -18,9 +17,10 @@ from static_analysis_bot import taskcluster
 from static_analysis_bot.config import settings
 from static_analysis_bot.report import get_reporters
 from static_analysis_bot.revisions import Revision
+from static_analysis_bot.tools.log import init_logger
 from static_analysis_bot.workflow import Workflow
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def parse_cli():

--- a/src/staticanalysis/bot/static_analysis_bot/cli.py
+++ b/src/staticanalysis/bot/static_analysis_bot/cli.py
@@ -71,8 +71,6 @@ def main():
                 PAPERTRAIL_HOST=taskcluster.secrets.get('PAPERTRAIL_HOST'),
                 PAPERTRAIL_PORT=taskcluster.secrets.get('PAPERTRAIL_PORT'),
                 SENTRY_DSN=taskcluster.secrets.get('SENTRY_DSN'),
-                MOZDEF=taskcluster.secrets.get('MOZDEF'),
-                timestamp=True,
                 )
 
     # Setup settings before stats

--- a/src/staticanalysis/bot/static_analysis_bot/config.py
+++ b/src/staticanalysis/bot/static_analysis_bot/config.py
@@ -12,15 +12,14 @@ import os
 import tempfile
 
 import requests
+import structlog
 import yaml
-
-from cli_common.log import get_logger
 
 PROJECT_NAME = 'static-analysis-bot'
 REPO_TRY = b'https://hg.mozilla.org/try'
 RAW_FILE_URL = 'https://hg.mozilla.org/mozilla-central/raw-file/tip/{}'
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 TaskCluster = collections.namedtuple('TaskCluster', 'results_dir, task_id, run_id, local')
 

--- a/src/staticanalysis/bot/static_analysis_bot/report/__init__.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/__init__.py
@@ -3,11 +3,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from cli_common.log import get_logger
+import structlog
+
 from static_analysis_bot.report.mail import MailReporter
 from static_analysis_bot.report.phabricator import PhabricatorReporter
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def get_reporters(configuration):

--- a/src/staticanalysis/bot/static_analysis_bot/report/debug.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/debug.py
@@ -7,10 +7,11 @@ import json
 import os.path
 import time
 
-from cli_common import log
+import structlog
+
 from static_analysis_bot.report.base import Reporter
 
-logger = log.get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class DebugReporter(Reporter):

--- a/src/staticanalysis/bot/static_analysis_bot/report/mail.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/mail.py
@@ -3,12 +3,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from cli_common import log
+import structlog
+
 from static_analysis_bot import taskcluster
 from static_analysis_bot.config import settings
 from static_analysis_bot.report.base import Reporter
 
-logger = log.get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 EMAIL_STATS_LINE = '* **{source}**: {publishable} publishable ({total} total)'

--- a/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
+++ b/src/staticanalysis/bot/static_analysis_bot/report/phabricator.py
@@ -3,10 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import structlog
 from libmozdata.phabricator import BuildState
 from libmozdata.phabricator import PhabricatorAPI
 
-from cli_common import log
 from static_analysis_bot import CLANG_FORMAT
 from static_analysis_bot import COVERAGE
 from static_analysis_bot import Issue
@@ -21,7 +21,7 @@ BUG_REPORT_URL = 'https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Bui
 # These analyzers generate issues for which we should not write inline comments.
 ANALYZERS_WITHOUT_INLINES = [CLANG_FORMAT, COVERAGE]
 
-logger = log.get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class PhabricatorReporter(Reporter):

--- a/src/staticanalysis/bot/static_analysis_bot/revisions.py
+++ b/src/staticanalysis/bot/static_analysis_bot/revisions.py
@@ -6,18 +6,18 @@
 import os
 from datetime import timedelta
 
+import structlog
 from libmozdata.phabricator import BuildState
 from libmozdata.phabricator import PhabricatorAPI
 from parsepatch.patch import Patch
 
-from cli_common import log
 from static_analysis_bot import Issue
 from static_analysis_bot import stats
 from static_analysis_bot.config import REPO_TRY
 from static_analysis_bot.config import settings
 from static_analysis_bot.tools.taskcluster import create_blob_artifact
 
-logger = log.get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class ImprovementPatch(object):

--- a/src/staticanalysis/bot/static_analysis_bot/tasks/base.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/base.py
@@ -3,9 +3,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from cli_common.log import get_logger
+import structlog
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 WORKER_CHECKOUT = '/builds/worker/checkouts/gecko'
 

--- a/src/staticanalysis/bot/static_analysis_bot/tasks/clang_format.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/clang_format.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
+import structlog
 from libmozdata.phabricator import LintResult
 
-from cli_common.log import get_logger
 from static_analysis_bot import CLANG_FORMAT
 from static_analysis_bot import Issue
 from static_analysis_bot.config import settings
 from static_analysis_bot.tasks.base import AnalysisTask
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 ISSUE_MARKDOWN = '''
 ## clang-format

--- a/src/staticanalysis/bot/static_analysis_bot/tasks/clang_tidy.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/clang_tidy.py
@@ -6,16 +6,16 @@
 
 import re
 
+import structlog
 from libmozdata.phabricator import LintResult
 
-from cli_common.log import get_logger
 from static_analysis_bot import CLANG_TIDY
 from static_analysis_bot import Issue
 from static_analysis_bot import Reliability
 from static_analysis_bot.config import settings
 from static_analysis_bot.tasks.base import AnalysisTask
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 ISSUE_MARKDOWN = '''

--- a/src/staticanalysis/bot/static_analysis_bot/tasks/coverage.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/coverage.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 import os
 
-from cli_common.log import get_logger
+import structlog
+
 from static_analysis_bot import COVERAGE
 from static_analysis_bot import Issue
 from static_analysis_bot.config import settings
 from static_analysis_bot.tasks.base import AnalysisTask
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 ISSUE_MARKDOWN = '''
 ## coverage problem

--- a/src/staticanalysis/bot/static_analysis_bot/tasks/coverity.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/coverity.py
@@ -3,15 +3,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import structlog
 from libmozdata.phabricator import LintResult
 
-from cli_common.log import get_logger
 from static_analysis_bot import COVERITY
 from static_analysis_bot import Issue
 from static_analysis_bot import Reliability
 from static_analysis_bot.tasks.base import AnalysisTask
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 ISSUE_MARKDOWN = '''
 ## coverity error

--- a/src/staticanalysis/bot/static_analysis_bot/tasks/infer.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/infer.py
@@ -3,14 +3,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import structlog
 from libmozdata.phabricator import LintResult
 
-from cli_common.log import get_logger
 from static_analysis_bot import INFER
 from static_analysis_bot import Issue
 from static_analysis_bot.tasks.base import AnalysisTask
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 ISSUE_MARKDOWN = '''
 ## infer error

--- a/src/staticanalysis/bot/static_analysis_bot/tasks/lint.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tasks/lint.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
+import structlog
 from libmozdata.phabricator import LintResult
 
-from cli_common.log import get_logger
 from static_analysis_bot import MOZLINT
 from static_analysis_bot import Issue
 from static_analysis_bot.tasks.base import AnalysisTask
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 ISSUE_MARKDOWN = '''
 ## mozlint - {linter}

--- a/src/staticanalysis/bot/static_analysis_bot/tools/log.py
+++ b/src/staticanalysis/bot/static_analysis_bot/tools/log.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
+import logbook
+import logbook.more
+import structlog
+
+
+class UnstructuredRenderer(structlog.processors.KeyValueRenderer):
+
+    def __call__(self, logger, method_name, event_dict):
+        event = None
+        if 'event' in event_dict:
+            event = event_dict.pop('event')
+        if event_dict or event is None:
+            # if there are other keys, use the parent class to render them
+            # and append to the event
+            rendered = super(UnstructuredRenderer, self).__call__(
+                logger, method_name, event_dict)
+            return f'{event} ({rendered})'
+        else:
+            return event
+
+
+def setup_papertrail(project_name, channel, PAPERTRAIL_HOST, PAPERTRAIL_PORT):
+    '''
+    Setup papertrail account using taskcluster secrets
+    '''
+
+    # Setup papertrail
+    papertrail = logbook.SyslogHandler(
+        application_name=f'mozilla/release-services/{channel}/{project_name}',
+        address=(PAPERTRAIL_HOST, int(PAPERTRAIL_PORT)),
+        level=logbook.INFO,
+        format_string='{record.time} {record.channel}: {record.message}',
+        bubble=True,
+    )
+    papertrail.push_application()
+
+
+def setup_sentry(project_name, channel, SENTRY_DSN):
+    '''
+    Setup sentry account using taskcluster secrets
+    '''
+
+    import raven
+    import raven.handlers.logbook
+
+    sentry_client = raven.Client(
+        dsn=SENTRY_DSN,
+        site=project_name,
+        name='mozilla/release-services',
+        environment=channel,
+        # TODO:
+        # release=read(VERSION) we need to promote that as well via secrets
+        # tags=...
+        # repos=...
+    )
+
+    sentry_handler = raven.handlers.logbook.SentryHandler(
+        sentry_client,
+        level=logbook.WARNING,
+        bubble=True,
+    )
+    sentry_handler.push_application()
+
+
+def init_logger(project_name,
+                channel=None,
+                level=logbook.INFO,
+                PAPERTRAIL_HOST=None,
+                PAPERTRAIL_PORT=None,
+                SENTRY_DSN=None
+                ):
+
+    if not channel:
+        channel = os.environ.get('APP_CHANNEL')
+
+    # Output logs on stderr, with color support on consoles
+    fmt = '{record.time} [{record.level_name:<8}] {record.channel}: {record.message}'
+    handler = logbook.more.ColorizedStderrHandler(level=level, format_string=fmt)
+    handler.push_application()
+
+    # Log to papertrail
+    if channel and PAPERTRAIL_HOST and PAPERTRAIL_PORT:
+        setup_papertrail(project_name, channel, PAPERTRAIL_HOST, PAPERTRAIL_PORT)
+
+    # Log to senty
+    if channel and SENTRY_DSN:
+        setup_sentry(project_name, channel, SENTRY_DSN)
+
+    def logbook_factory(*args, **kwargs):
+        # Logger given to structlog
+        logbook.compat.redirect_logging()
+        return logbook.Logger(level=level, *args, **kwargs)
+
+    # Setup structlog over logbook, with args list at the end
+    processors = [
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        UnstructuredRenderer(),
+    ]
+
+    structlog.configure(
+        context_class=structlog.threadlocal.wrap_dict(dict),
+        processors=processors,
+        logger_factory=logbook_factory,
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )

--- a/src/staticanalysis/bot/static_analysis_bot/workflow.py
+++ b/src/staticanalysis/bot/static_analysis_bot/workflow.py
@@ -6,10 +6,10 @@
 from datetime import datetime
 from datetime import timedelta
 
+import structlog
 from libmozdata.phabricator import BuildState
 from libmozdata.phabricator import PhabricatorAPI
 
-from cli_common.log import get_logger
 from static_analysis_bot import stats
 from static_analysis_bot.config import settings
 from static_analysis_bot.report.debug import DebugReporter
@@ -23,7 +23,7 @@ from static_analysis_bot.tasks.infer import InferTask
 from static_analysis_bot.tasks.lint import MozLintTask
 from static_analysis_bot.tools.taskcluster import TASKCLUSTER_DATE_FORMAT
 
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 TASKCLUSTER_NAMESPACE = 'project.releng.services.project.{channel}.static_analysis_bot.{name}'
 TASKCLUSTER_INDEX_TTL = 7  # in days


### PR DESCRIPTION
* Removes deprecated MOZDEF support
* Keep publishing on papertrail & sentry
* A bit nicer format (colors on console when available, better display of level, time & module)
* Removes `cli_common` usage as it was the last part using it.