### PR TITLE
Add option to trigger one task per day.

### DIFF
--- a/src/codecoverage/bot/tools/covdir_gen.py
+++ b/src/codecoverage/bot/tools/covdir_gen.py
@@ -13,7 +13,7 @@ from code_coverage_bot.secrets import secrets
 CODECOV_URL = 'https://codecov.io/api/gh/marco-c/gecko-dev/commit'
 MC_REPO = 'https://hg.mozilla.org/mozilla-central'
 HOOK_GROUP = 'project-releng'
-HOOK_ID = 'services-{app_channel}-codecoverage/bot'
+HOOK_ID = 'services-{app_channel}-codecoverage/bot-generation'
 
 secrets.load(
     os.environ['TASKCLUSTER_SECRET'],

--- a/src/codecoverage/bot/tools/covdir_gen.py
+++ b/src/codecoverage/bot/tools/covdir_gen.py
@@ -68,7 +68,7 @@ def list_commits(maximum=None, unique_dates=False, skip_commits=[]):
         params['page'] += 1
 
 
-def trigger_task(task_group_id, commit, skip_commits=[]):
+def trigger_task(task_group_id, commit):
     '''
     Trigger a code coverage task to build covdir at a specified revision
     '''


### PR DESCRIPTION
Add 2 options to `tools/covdir_gen.py`:

1. `--unique-dates` will trigger only one task per day
2. `--group=XXX` allow specifying an existing taskcluster group with code coverage generation tasks, and will skip the existing commits: this permits to create small batches of tasks in a same group:

For example on prod, this command will add the next 3 days of code coverage [not yet processed in the task group](https://tools.taskcluster.net/groups/MNmrH4EXSx6zmohMfWVTxw).

```shell
python tools/covdir_gen.py --unique-dates --nb-tasks=3 --group=MNmrH4EXSx6zmohMfWVTxw
```
