### PR TITLE
Bug 1556784 - 68 train: Rename `{promote,ship}_fennec` into `{promote…

### DIFF
--- a/src/shipit/frontend/src/configs/production.js
+++ b/src/shipit/frontend/src/configs/production.js
@@ -54,6 +54,7 @@ module.exports = {
           branch: 'releases/mozilla-beta',
           repo: 'https://hg.mozilla.org/releases/mozilla-beta',
           enableReleaseEta: false,
+          productKey: 'fennec_beta',
           versionFile: 'mobile/android/config/version-files/beta/version_display.txt',
         },
         {


### PR DESCRIPTION
…,ship}_fennec_beta`

It must be deployed at around the same time https://phabricator.services.mozilla.com/D33657 reaches mozilla-beta. The order doesn't matter. 

r? @rail 