### PR TITLE
Bug 1558507 - Move Fennec Beta to mozilla-esr68

### DIFF
--- a/src/shipit/frontend/src/configs/production.js
+++ b/src/shipit/frontend/src/configs/production.js
@@ -50,9 +50,9 @@ module.exports = {
       branches: [
         {
           prettyName: 'Beta',
-          project: 'mozilla-beta',
-          branch: 'releases/mozilla-beta',
-          repo: 'https://hg.mozilla.org/releases/mozilla-beta',
+          project: 'mozilla-esr68',
+          branch: 'releases/mozilla-esr68',
+          repo: 'https://hg.mozilla.org/releases/mozilla-esr68',
           enableReleaseEta: false,
           productKey: 'fennec_beta',
           versionFile: 'mobile/android/config/version-files/beta/version_display.txt',


### PR DESCRIPTION
Follows https://github.com/mozilla/release-services/pull/2155 up

r? @rail 

I'd need to get this landed before the next go-to-build on Thursday. Do you think it can be deployed by then? 