### PR TITLE
pulselistener: Write try_task_config.json for NSS too

### DIFF
--- a/src/pulselistener/pulselistener/mercurial.py
+++ b/src/pulselistener/pulselistener/mercurial.py
@@ -45,6 +45,7 @@ class Repository(object):
         self.try_url = config['try_url']
         self.try_mode = TryMode(config.get('try_mode', 'json'))
         self.try_syntax = config.get('try_syntax')
+        self.default_revision = config.get('default_revision', 'tip')
         if self.try_mode == TryMode.syntax:
             assert self.try_syntax, 'Missing try syntax'
 
@@ -245,7 +246,11 @@ class MercurialWorker(object):
             repository.clean()
 
             # Get the stack of patches
-            base, patches = self.phabricator_api.load_patches_stack(repository.repo, build.diff, default_revision='central')
+            base, patches = self.phabricator_api.load_patches_stack(
+                repository.repo,
+                build.diff,
+                default_revision=repository.default_revision,
+            )
             assert len(patches) > 0, 'No patches to apply'
 
             # Load all the diffs details with commits messages

--- a/src/pulselistener/tests/test_mercurial.py
+++ b/src/pulselistener/tests/test_mercurial.py
@@ -435,7 +435,7 @@ async def test_push_to_try_nss(PhabricatorMock, mock_nss):
 
     # The patched and config files should not exist at first
     repo_dir = mock_nss.root().decode('utf-8')
-    config = os.path.join(repo_dir, '.try')
+    config = os.path.join(repo_dir, 'try_task_config.json')
     target = os.path.join(repo_dir, 'test.txt')
     assert not os.path.exists(target)
     assert not os.path.exists(config)
@@ -480,6 +480,17 @@ async def test_push_to_try_nss(PhabricatorMock, mock_nss):
     # The target should have content now
     assert os.path.exists(target)
     assert open(target).read() == 'First Line\nSecond Line\n'
+
+    # The config should have content now
+    assert os.path.exists(config)
+    assert json.load(open(config)) == {
+        'version': 2,
+        'parameters': {
+            'code-review': {
+                'phabricator-build-target': 'PHID-HMBT-deadbeef',
+            }
+        },
+    }
 
     # Get tip commit in repo
     # It should be different from the initial one (patches + config have applied)


### PR DESCRIPTION
On new NSS patches, pulselistener will apply the stack of patches, then add a commit with `try_task_config.json` with the following content:

```json
{
  "version": 2,
  "parameters": {
    "code-review": {
       "phabricator-build-target": "PHID-HMBT-xxx123",
    }
  }
}
```
This content is using the same format as [mozilla-central try v2](https://firefox-source-docs.mozilla.org/main/latest/taskcluster/taskcluster/try.html#complex-configuration)

The commit message will have the try syntax setup in the Taskcluster secret (`try: -p none -t coverity` for NSS)

