### PR TITLE
shipit/api: parse version per product

### DIFF
--- a/src/shipit/api/shipit_api/product_details.py
+++ b/src/shipit/api/shipit_api/product_details.py
@@ -6,7 +6,6 @@
 import asyncio
 import collections
 import datetime
-import enum
 import functools
 import hashlib
 import io
@@ -31,25 +30,10 @@ import cli_common.log
 import cli_common.utils
 import shipit_api.config
 import shipit_api.models
+from shipit_api.release import Product
+from shipit_api.release import ProductCategory
 
 logger = cli_common.log.get_logger(__name__)
-
-
-@enum.unique
-class Product(enum.Enum):
-    DEVEDITION = 'devedition'
-    FIREFOX = 'firefox'
-    FENNEC = 'fennec'
-    THUNDERBIRD = 'thunderbird'
-
-
-@enum.unique
-class ProductCategory(enum.Enum):
-    MAJOR = 'major'
-    DEVELOPMENT = 'dev'
-    STABILITY = 'stability'
-    ESR = 'esr'
-
 
 File = str
 ReleaseDetails = mypy_extensions.TypedDict('ReleaseDetails', {

--- a/src/shipit/api/shipit_api/release.py
+++ b/src/shipit/api/shipit_api/release.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import enum
 import re
 
 # If version has two parts with no trailing specifiers like "rc", we
@@ -20,6 +21,22 @@ VERSION_REGEX = re.compile(
     r'(?P<esr>(?:esr)?)'  # ESR indicator
     r'$'
 )
+
+
+@enum.unique
+class Product(enum.Enum):
+    DEVEDITION = 'devedition'
+    FIREFOX = 'firefox'
+    FENNEC = 'fennec'
+    THUNDERBIRD = 'thunderbird'
+
+
+@enum.unique
+class ProductCategory(enum.Enum):
+    MAJOR = 'major'
+    DEVELOPMENT = 'dev'
+    STABILITY = 'stability'
+    ESR = 'esr'
 
 
 def parse_version(version):


### PR DESCRIPTION
In gecko 68 we started building Fennec using mozilla-esr68 and beta
numbers became something like 68.1b1. `FirefoxVersion` won't accept this
kind of versions. It would be better to use per product classes to parse
versions.