### PR TITLE
shipit/api: import releases from API

### DIFF
--- a/src/shipit/api/settings.py
+++ b/src/shipit/api/settings.py
@@ -145,9 +145,7 @@ AUTH0_AUTH_SCOPES.update(scopes)
 
 # other scopes
 AUTH0_AUTH_SCOPES.update({
-    'sync_releases': [],
     'rebuild_product_details': [],
-    'sync_release_datetimes': [],
     'update_release_status': [],
 })
 

--- a/src/shipit/api/setup.py
+++ b/src/shipit/api/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     entry_points=dict(
         console_scripts=[
-            'shipit-v1-sync = shipit_api.cli:v1_sync',
+            'shipit-import = shipit_api.cli:shipit_import',
             'shipit-download-product-details = shipit_api.cli:download_product_details',
             'shipit-rebuild-product-details = shipit_api.cli:rebuild_product_details',
             'shipit-trigger-product-details = shipit_api.cli:trigger_product_details',

--- a/src/shipit/api/shipit_api/api.yml
+++ b/src/shipit/api/shipit_api/api.yml
@@ -40,52 +40,6 @@ paths:
         200:
           description: Product details rebuild triggered.
 
-  /sync:
-    post:
-      summary: Sync release data from Ship-it v1
-      operationId: shipit_api.api.sync_releases
-      consumes:
-      - "application/json"
-      parameters:
-      - in: body
-        name: releases
-        description: Releases array
-        required: true
-        schema:
-          type: array
-          items:
-            type: object
-      responses:
-        405:
-          description: Invalid input
-        201:
-          description: Releases synced
-          schema:
-            type: object
-
-  /sync_datetime:
-    post:
-      summary: Sync release datetimes from Ship-it v1
-      operationId: shipit_api.api.sync_release_datetimes
-      consumes:
-      - "application/json"
-      parameters:
-      - in: body
-        name: releases
-        description: Releases array
-        required: true
-        schema:
-          type: array
-          items:
-            type: object
-      responses:
-        405:
-          description: Invalid input
-        201:
-          description: Releases synced
-          schema:
-            type: object
-
   /releases:
     post:
       summary: Add a new release

--- a/src/shipit/api/shipit_api/cli.py
+++ b/src/shipit/api/shipit_api/cli.py
@@ -192,6 +192,7 @@ def shipit_import(api_from):
 
     click.echo('Fetching release list...', nl=False)
     req = requests.get(f'{api_from}/releases?status=shipped,aborted,scheduled')
+    req.raise_for_status()
     releases = req.json()
 
     for release in releases:

--- a/src/shipit/api/shipit_api/cli.py
+++ b/src/shipit/api/shipit_api/cli.py
@@ -19,8 +19,8 @@ import requests
 import sqlalchemy
 import sqlalchemy.orm
 
-from shipit_api.models import Release
 import shipit_api.product_details
+from shipit_api.models import Release
 
 
 def coroutine(f):

--- a/src/shipit/api/shipit_api/cli.py
+++ b/src/shipit/api/shipit_api/cli.py
@@ -14,6 +14,7 @@ import aiohttp
 import backoff
 import click
 import flask
+import flask.cli
 import mohawk
 import requests
 import sqlalchemy


### PR DESCRIPTION
* Remove the old sync API, shipit v1 is EOL
* Add ability to import releases. It is very useful for local
  development