### PR TITLE
shipit/api: add ESR_NEXT in primary_builds.json

### DIFF
--- a/src/shipit/api/shipit_api/product_details.py
+++ b/src/shipit/api/shipit_api/product_details.py
@@ -595,6 +595,8 @@ def get_primary_builds(breakpoint_version: int,
             firefox_versions['LATEST_FIREFOX_VERSION'],
             firefox_versions['FIREFOX_ESR'],
         ])
+        if firefox_versions['FIREFOX_ESR_NEXT']:
+            versions.add(firefox_versions['FIREFOX_ESR_NEXT'])
     elif product is Product.THUNDERBIRD:
         thunderbird_versions = get_thunderbird_versions(releases)
         products = [Product.THUNDERBIRD]


### PR DESCRIPTION
When we have 2 ESR releases active at the same time, we want them both
to be in `firefox_primary_builds.json`