### PR TITLE
pulselistener: Support custom hookGroupId

### DIFF
--- a/src/pulselistener/pulselistener/listener.py
+++ b/src/pulselistener/pulselistener/listener.py
@@ -26,7 +26,7 @@ class HookPhabricator(Hook):
     def __init__(self, configuration):
         assert 'hookId' in configuration
         super().__init__(
-            'project-releng',
+            configuration.get('hookGroupId', 'project-releng'),
             configuration['hookId'],
         )
 
@@ -140,7 +140,7 @@ class HookCodeCoverage(PulseHook):
         assert 'hookId' in configuration
         self.triggered_groups = set()
         super().__init__(
-            'project-releng',
+            configuration.get('hookGroupId', 'project-releng'),
             configuration['hookId'],
             'exchange/taskcluster-queue/v1/task-group-resolved',
             '#'

--- a/src/pulselistener/tests/test_code_coverage_listener.py
+++ b/src/pulselistener/tests/test_code_coverage_listener.py
@@ -136,3 +136,18 @@ def test_success_try():
     assert hook.parse({
         'taskGroupId': 'FG3goVnCQfif8ZEOaM_4IA'
     }) == [{'REPOSITORY': 'https://hg.mozilla.org/try', 'REVISION': '066cb18ba95a7efe144e729713c429e422d9f95b'}]
+
+
+def test_hook_group():
+    hook = HookCodeCoverage({
+      'hookId': 'services-staging-codecoverage/bot'
+    })
+    assert hook.group_id == 'project-releng'
+    assert hook.hook_id == 'services-staging-codecoverage/bot'
+
+    hook = HookCodeCoverage({
+      'hookGroupId': 'anotherProject',
+      'hookId': 'anotherHook',
+    })
+    assert hook.group_id == 'anotherProject'
+    assert hook.hook_id == 'anotherHook'


### PR DESCRIPTION
Needed to trigger the new codecoverage hooks.