### PR TITLE
Fix boot sequence

### DIFF
--- a/src/pulselistener/pulselistener/lib/bus.py
+++ b/src/pulselistener/pulselistener/lib/bus.py
@@ -59,6 +59,12 @@ class MessageBus(object):
         if isinstance(queue, asyncio.Queue):
             return await queue.get()
         else:
+
+            # This sleep call is needed to avoid fully blocking
+            # async process waiting on a multiprocessing queue
+            # Exemple: code review workflow waiting for new builds from webserver
+            await asyncio.sleep(0)
+
             return queue.get()
 
     async def run(self, input_name, output_name, method):


### PR DESCRIPTION
Without this sleep call, the mercurial worker does not start cloning the repositories, and pulselistener never triggers the builds later on.
