### PR TITLE
adds product to is_rc for thunderbird edge case

### DIFF
--- a/src/shipit/api/shipit_api/release.py
+++ b/src/shipit/api/shipit_api/release.py
@@ -5,6 +5,7 @@
 
 import enum
 import re
+from shipit_api.config import SUPPORTED_FLAVORS
 
 # If version has two parts with no trailing specifiers like "rc", we
 # consider it a 'final' release for which we only create a _RELEASE tag.
@@ -58,10 +59,16 @@ def is_esr(version):
     return parse_version(version)['esr'] == 'esr'
 
 
-def is_rc(version, partial_updates):
+def is_rc(product, version, partial_updates):
     if not is_beta(version) and not is_esr(version):
         if is_final_release(version):
-            return True
+            # version supports rc flavor
+            # now validate that the product itself supports rc flavor
+            if SUPPORTED_FLAVORS.get(f'{product}_rc'):
+                # could hard code "Thunderbird" condition here but
+                # suspect it's better to use SUPPORTED_FLAVORS for a
+                # configuration driven decision.
+                return True
         # RC release types will enable beta-channel testing &
         # shipping. We need this for all "final" releases
         # and also any releases that include a beta as a partial.

--- a/src/shipit/api/shipit_api/release.py
+++ b/src/shipit/api/shipit_api/release.py
@@ -5,6 +5,7 @@
 
 import enum
 import re
+
 from shipit_api.config import SUPPORTED_FLAVORS
 
 # If version has two parts with no trailing specifiers like "rc", we

--- a/src/shipit/api/shipit_api/tasks.py
+++ b/src/shipit/api/shipit_api/tasks.py
@@ -63,7 +63,7 @@ def extract_our_flavors(avail_flavors, product, version, partial_updates, produc
     if not product_key:
         product_key = product
 
-    if is_rc(version, partial_updates):
+    if is_rc(product_key, version, partial_updates):
         product_key = f'{product_key}_rc'
 
     # sanity check

--- a/src/shipit/api/tests/test_release.py
+++ b/src/shipit/api/tests/test_release.py
@@ -50,16 +50,20 @@ def test_is_esr(version, result):
     assert is_esr(version) == result
 
 
-@pytest.mark.parametrize('version, partial_updates, result', (
-    ('57.0', {'56.0b1': [], '55.0': []}, True),
-    ('57.0', {'56.0': [], '55.0': []}, True),
-    ('64.0', None, True),
-    ('64.0.1', None, False),
-    ('56.0b3', None, False),
-    ('41.0esr', None, False),
+@pytest.mark.parametrize('product, version, partial_updates, result', (
+    ('firefox', '57.0', {'56.0b1': [], '55.0': []}, True),
+    ('firefox', '57.0', {'56.0': [], '55.0': []}, True),
+    ('thunderbird', '57.0', {'56.0': [], '55.0': []}, False),
+    ('firefox', '64.0', None, True),
+    ('thunderbird', '64.0', None, False),
+    ('fennec', '64.0', None, True),
+    ('firefox', '64.0.1', None, False),
+    ('thunderbird', '64.0.1', None, False),
+    ('fennec', '56.0b3', None, False),
+    ('firefox', '41.0esr', None, False),
 ))
-def test_is_rc(version, partial_updates, result):
-    assert is_rc(version, partial_updates) == result
+def test_is_rc(product, version, partial_updates, result):
+    assert is_rc(product, version, partial_updates) == result
 
 
 @pytest.mark.parametrize('version, result', (


### PR DESCRIPTION
context:

wsmwk> mhentges: i'm getting an auth failure in shipit trying to "start tracking" for thunderbird
bhearsum> i found the exception for the thunderbird issue: https://gist.github.com/mozbhearsum/2ab0ceadf1122c18140ff16b75916bfa
closemozbhearsum — 8 Aug 2019
13:22:52 
<•bhearsum> (it was on Sentry, for those with acccess: https://sentry.prod.mozaws.net/operations/mozilla-releng-services/issues/6127311/?query=is:unresolved%20is:unassigned)
14:47:32 
<•jlund> should thunderbird have an rc flavour? Does it push release builds to beta first?
14:47:37 it's not in https://github.com/mozilla/release-services/blob/4567698690d6cce5bf2a685c04021774125294cd/src/shipit/api/shipit_api/config.py#L432
14:47:45 but code thinks it should be: https://github.com/mozilla/release-services/blob/eabe5ca63fbe1e5bea48c1c450e0cce72b1309e4/src/shipit/api/settings.py#L137
14:49:44 whens the last time we did a thunderbird release on the release channel? this is 6month old code..
14:51:23 
<•aki> good questions. beta and esr only maybe? (i am not the expert)
14:52:19 
<•jlund> oh, actually I think this is the bug: https://github.com/mozilla/release-services/pull/2181/files
14:54:07 because is_rc() is assuming if the release is not a dot release, it's an rc, even for thunderbird
14:54:08 https://github.com/mozilla/release-services/blob/e3ca5565c4108e76d33cfd2dedec20248dcfc58f/src/shipit/api/shipit_api/release.py#L61
14:54:21 
<•aki> aha. maybe is_rc should take product as well
14:54:34 
<•jlund> ++
14:55:03 
— •jlund writes a patch