### PR TITLE
Pulselistener fixes

### DIFF
--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -83,6 +83,7 @@ PROJECTS_CONFIG = {
         'run': 'REDIS',
         'run_options': {
             'port': 6379,
+            'schema': 'redis',
             'data_dir': os.path.join(TMP_DIR, 'redis'),
         },
     },
@@ -377,7 +378,7 @@ PROJECTS_CONFIG = {
     },
     'pulselistener': {
         'update': False,
-        'requires': [],
+        'requires': ['redis'],
         'deploys': [
             {
                 'target': 'HEROKU',

--- a/nix/tools/mercurial.nix
+++ b/nix/tools/mercurial.nix
@@ -8,8 +8,8 @@ let
   hg_tools = mkDerivation {
     name = "mozilla-hg-tools";
     src = fetchurl {
-      url = "https://hg.mozilla.org/hgcustom/version-control-tools/archive/6cd994e30bb1.tar.bz2";
-      sha256 = "0dh82jz7b1qqfv7ghrzf6xdgcgpk10z7338d90inyckk0naiac5g";
+      url = "https://hg.mozilla.org/hgcustom/version-control-tools/archive/307f3c28687630bf91b4c19c913f0c677e0ae724.tar.bz2";
+      sha256 = "0m7s6vnmbyfps9gp7pspr5x6y8czj0adp8d5hq6n5gl18xrjhdhg";
     };
     installPhase = ''
       mkdir -p $out
@@ -25,8 +25,8 @@ let
     };
   };
 
-  # Stick to 4.8, which is supported by version-control-tools.
-  version = "4.8";
+  # Stick to 5.1, which is supported by version-control-tools.
+  version = "5.1";
   name = "mercurial-${version}";
 
 in python2Packages.buildPythonApplication {
@@ -35,7 +35,7 @@ in python2Packages.buildPythonApplication {
 
   src = fetchurl {
     url = "https://mercurial-scm.org/release/${name}.tar.gz";
-    sha256 = "00rzjbf2blxkc0qwd9mdzx5fnzgpp4jxzijq6wgsjgmqscx40sy5";
+    sha256 = "0af8wx5sn35l8c8sfj7cabx15i9b2di81ibx5d11wh8fhqnxj8k2";
   };
 
   buildInputs = [ makeWrapper python2Packages.docutils unzip ];

--- a/src/pulselistener/pulselistener/code_review.py
+++ b/src/pulselistener/pulselistener/code_review.py
@@ -57,6 +57,8 @@ class CodeReview(PhabricatorActions):
 
             # Receive build from webserver
             build = await self.bus.receive(QUEUE_WEB_BUILDS)
+            if build is None:
+                continue
             assert isinstance(build, PhabricatorBuild)
 
             # Update its state

--- a/src/pulselistener/pulselistener/code_review.py
+++ b/src/pulselistener/pulselistener/code_review.py
@@ -57,8 +57,7 @@ class CodeReview(PhabricatorActions):
 
             # Receive build from webserver
             build = await self.bus.receive(QUEUE_WEB_BUILDS)
-            if build is None:
-                continue
+            assert build is not None, 'Invalid payload'
             assert isinstance(build, PhabricatorBuild)
 
             # Update its state

--- a/src/pulselistener/pulselistener/lib/bus.py
+++ b/src/pulselistener/pulselistener/lib/bus.py
@@ -83,7 +83,6 @@ class MessageBus(object):
                 return pickle.loads(payload)
             except Exception as e:
                 logger.error('Bad redis payload', error=str(e))
-                await asyncio.sleep(1)
                 return
 
         elif isinstance(queue, asyncio.Queue):

--- a/src/pulselistener/pulselistener/lib/bus.py
+++ b/src/pulselistener/pulselistener/lib/bus.py
@@ -5,7 +5,6 @@ import inspect
 import multiprocessing
 import os
 import pickle
-from queue import Empty
 
 import aioredis
 import structlog
@@ -92,15 +91,7 @@ class MessageBus(object):
 
         else:
             # Run the synchronous mp queue.get in the asynchronous loop
-            # but use an asyncio sleep to be able to react to cancellation
-            async def _get():
-                while True:
-                    try:
-                        return queue.get(timeout=0)
-                    except Empty:
-                        await asyncio.sleep(1)
-
-            return await _get()
+            return await asyncio.get_running_loop().run_in_executor(None, queue.get)
 
     async def run(self, method, input_name, output_name=None):
         '''

--- a/src/pulselistener/pulselistener/lib/bus.py
+++ b/src/pulselistener/pulselistener/lib/bus.py
@@ -8,10 +8,9 @@ import pickle
 from queue import Empty
 
 import aioredis
+import structlog
 
-from cli_common.log import get_logger
-
-logger = get_logger(__name__)
+logger = structlog.get_logger(__name__)
 
 RedisQueue = collections.namedtuple('RedisQueue', 'name')
 

--- a/src/pulselistener/pulselistener/lib/bus.py
+++ b/src/pulselistener/pulselistener/lib/bus.py
@@ -63,7 +63,7 @@ class MessageBus(object):
 
         if isinstance(queue, RedisQueue):
             async with AsyncRedis() as redis:
-                nb = await redis.rpush(queue.name, pickle.dumps(payload))
+                nb = await redis.rpush(queue.name, pickle.dumps(payload, pickle.HIGHEST_PROTOCOL))
                 logger.info('Put new item in redis queue', queue=queue.name, nb=nb)
 
         elif isinstance(queue, asyncio.Queue):
@@ -89,7 +89,7 @@ class MessageBus(object):
                 assert isinstance(payload, bytes)
                 logger.info('Read item from redis queue', queue=queue.name)
                 try:
-                    return pickle.loads(payload)
+                    return pickle.loads(payload, pickle.HIGHEST_PROTOCOL)
                 except Exception as e:
                     logger.error('Bad redis payload', error=str(e))
                     await asyncio.sleep(1)

--- a/src/pulselistener/pulselistener/lib/pulse.py
+++ b/src/pulselistener/pulselistener/lib/pulse.py
@@ -5,7 +5,6 @@
 
 import asyncio
 import json
-import sys
 
 import aioamqp
 import structlog
@@ -82,25 +81,6 @@ async def create_pulse_listener(user, password, exchange, topic, callback):
         await asyncio.sleep(10)
         # raise AmqpClosedConnection in case the connection is closed.
         await protocol.ensure_open()
-
-
-def run_consumer(consumer):
-    '''
-    Helper to run indefinitely an asyncio consumer
-    '''
-    event_loop = asyncio.get_event_loop()
-
-    try:
-        event_loop.run_until_complete(consumer)
-        event_loop.run_forever()
-    except KeyboardInterrupt:
-        # TODO: make better shutdown
-        logger.exception('KeyboardInterrupt registered, exiting.')
-        event_loop.stop()
-        while event_loop.is_running():
-            pass
-        event_loop.close()
-        sys.exit()
 
 
 class PulseListener(object):

--- a/src/pulselistener/pulselistener/lib/pulse.py
+++ b/src/pulselistener/pulselistener/lib/pulse.py
@@ -68,19 +68,14 @@ async def create_pulse_listener(user, password, exchange, topic, callback):
                                        type_name='topic',
                                        durable=True)
 
-    logger.info('Connected', queue=queue, topic=topic, exchange=exchange)
+    logger.info('Connected on pulse', queue=queue, topic=topic, exchange=exchange)
 
     await channel.queue_bind(exchange_name=exchange,
                              queue_name=queue,
                              routing_key=topic)
     await channel.basic_consume(callback, queue_name=queue)
 
-    logger.info('Worker starts consuming messages')
-    logger.info('Starting loop to ensure connection is open')
-    while True:
-        await asyncio.sleep(10)
-        # raise AmqpClosedConnection in case the connection is closed.
-        await protocol.ensure_open()
+    return protocol
 
 
 class PulseListener(object):
@@ -93,25 +88,37 @@ class PulseListener(object):
         self.route = route
         self.user = user
         self.password = password
-        logger.info('Listening for new messages', queue=queue, route=route)
 
     def register(self, bus):
         self.bus = bus
         self.bus.add_queue(self.queue_name)
 
+    async def connect(self):
+        protocol = await create_pulse_listener(
+            self.user,
+            self.password,
+            self.queue,
+            self.route,
+            self.got_message,
+        )
+        logger.info('Worker starts consuming messages', queue=self.queue)
+        return protocol
+
     async def run(self):
+        pulse = None
         while True:
             try:
-                await create_pulse_listener(
-                    self.user,
-                    self.password,
-                    self.queue,
-                    self.route,
-                    self.got_message,
-                )
-            except (aioamqp.AmqpClosedConnection, OSError):
-                logger.exception('Reconnecting in 10 seconds')
-                await asyncio.sleep(10)
+                if pulse is None:
+                    pulse = await self.connect()
+
+                # Check pulse server is still connected
+                # AmqpClosedConnection will be thrown otherwise
+                await pulse.ensure_open()
+                await asyncio.sleep(0)
+            except (aioamqp.AmqpClosedConnection, OSError) as e:
+                logger.exception('Reconnecting pulse client in 5 seconds', error=str(e))
+                pulse = None
+                await asyncio.sleep(5)
 
     async def got_message(self, channel, body, envelope, properties):
         '''
@@ -123,6 +130,7 @@ class PulseListener(object):
         body = json.loads(body.decode('utf-8'))
 
         # Push the message in the message bus
+        logger.debug('Received a pulse message')
         await self.bus.send(self.queue_name, body)
 
         # Ack the message so it is removed from the broker's queue

--- a/src/pulselistener/pulselistener/lib/utils.py
+++ b/src/pulselistener/pulselistener/lib/utils.py
@@ -112,3 +112,18 @@ def batch_checkout(repo_url, repo_dir, revision=b'tip', batch_size=100000):
     for rev in steps:
         log.info('Moving repo to revision', dir=repo_dir, rev=rev)
         repo.update(rev=rev)
+
+
+def robust_checkout(repo_url, repo_dir, branch=b'tip'):
+    '''
+    Helper to clone Mozilla Central using the robustcheckout extension
+    '''
+    assert isinstance(branch, bytes)
+
+    cmd = hglib.util.cmdbuilder('robustcheckout',
+                                repo_url,
+                                repo_dir,
+                                purge=True,
+                                sharebase=f'{repo_dir}-shared',
+                                branch=branch)
+    hg_run(cmd)

--- a/src/pulselistener/pulselistener/lib/utils.py
+++ b/src/pulselistener/pulselistener/lib/utils.py
@@ -38,7 +38,7 @@ def retry(operation,
 
 def run_tasks(awaitables):
     '''
-    Helper to run tasks concurrenlty, but when an exception is raised
+    Helper to run tasks concurrently, but when an exception is raised
     by one of the tasks, the whole stack stops.
     '''
     assert isinstance(awaitables, list)

--- a/src/pulselistener/pulselistener/lib/utils.py
+++ b/src/pulselistener/pulselistener/lib/utils.py
@@ -47,14 +47,14 @@ def run_tasks(awaitables):
         try:
             # Create a task grouping all awaitables
             # and running them concurrently
-            task = asyncio.gather(*awaitables)
-            await task
+            tasks_future = asyncio.gather(*awaitables)
+            await tasks_future
         except Exception as e:
             log.error('Failure while running async tasks', error=str(e))
 
             # When ANY exception from one of the awaitables
             # make sure the other awaitables are cancelled
-            task.cancel()
+            tasks_future.cancel()
 
     event_loop = asyncio.get_event_loop()
     event_loop.run_until_complete(_run())

--- a/src/pulselistener/pulselistener/lib/utils.py
+++ b/src/pulselistener/pulselistener/lib/utils.py
@@ -2,6 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import asyncio
 import fcntl
 import os
 import time
@@ -33,6 +34,30 @@ def retry(operation,
             if retries == 0:
                 raise
             time.sleep(wait_between_retries)
+
+
+def run_tasks(awaitables):
+    '''
+    Helper to run tasks concurrenlty, but when an exception is raised
+    by one of the tasks, the whole stack stops.
+    '''
+    assert isinstance(awaitables, list)
+
+    async def _run():
+        try:
+            # Create a task grouping all awaitables
+            # and running them concurrently
+            task = asyncio.gather(*awaitables)
+            await task
+        except Exception as e:
+            log.error('Failure while running async tasks', error=str(e))
+
+            # When ANY exception from one of the awaitables
+            # make sure the other awaitables are cancelled
+            task.cancel()
+
+    event_loop = asyncio.get_event_loop()
+    event_loop.run_until_complete(_run())
 
 
 def hg_run(cmd):
@@ -116,7 +141,7 @@ def batch_checkout(repo_url, repo_dir, revision=b'tip', batch_size=100000):
 
 def robust_checkout(repo_url, repo_dir, branch=b'tip'):
     '''
-    Helper to clone Mozilla Central using the robustcheckout extension
+    Helper to clone a mercurial repo using the robustcheckout extension
     '''
     assert isinstance(branch, bytes)
 

--- a/src/pulselistener/pulselistener/lib/web.py
+++ b/src/pulselistener/pulselistener/lib/web.py
@@ -15,6 +15,7 @@ class WebServer(object):
     WebServer used to receive hook
     '''
     def __init__(self, queue_name):
+        self.process = None
         self.http_port = int(os.environ.get('PORT', 9000))
         self.queue_name = queue_name
         logger.info('HTTP webhook server will listen', port=self.http_port)
@@ -38,11 +39,16 @@ class WebServer(object):
             web.run_app(self.app, port=self.http_port, print=logger.info)
 
         # Run webserver in its own process
-        server = Process(target=_run)
-        server.start()
-        logger.info('Web server started', pid=server.pid)
+        self.process = Process(target=_run)
+        self.process.start()
+        logger.info('Web server started', pid=self.process.pid)
 
-        return server
+        return self.process
+
+    def stop(self):
+        assert self.process is not None, 'Web server not started'
+        self.process.kill()
+        logger.info('Web server stopped')
 
     async def ping(self, request):
         '''

--- a/src/pulselistener/pulselistener/lib/web.py
+++ b/src/pulselistener/pulselistener/lib/web.py
@@ -28,7 +28,7 @@ class WebServer(object):
 
     def register(self, bus):
         self.bus = bus
-        self.bus.add_queue(self.queue_name, mp=True)
+        self.bus.add_queue(self.queue_name, mp=True, redis=True)
 
     def start(self):
         '''

--- a/src/pulselistener/pulselistener/listener.py
+++ b/src/pulselistener/pulselistener/listener.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import asyncio
+
 import requests
 import structlog
 
@@ -44,7 +46,7 @@ class CodeCoverage(object):
             payload = await self.bus.receive(QUEUE_PULSE_CODECOV)
 
             # Parse the payload to extract a new task's environment
-            envs = self.parse(payload)
+            envs = await self.parse(payload)
             if envs is None:
                 continue
 
@@ -60,12 +62,13 @@ class CodeCoverage(object):
     def is_coverage_task(self, task):
         return any(task['task']['metadata']['name'].startswith(s) for s in ['build-linux64-ccov', 'build-win64-ccov'])
 
-    def get_build_task_in_group(self, group_id):
+    async def get_build_task_in_group(self, group_id):
         if group_id in self.triggered_groups:
             logger.info('Received duplicated groupResolved notification', group=group_id)
             return None
 
         def maybe_trigger(tasks):
+            logger.info('Checking code coverage tasks', group_id=group_id, nb=len(tasks))
             for task in tasks:
                 if self.is_coverage_task(task):
                     self.triggered_groups.add(group_id)
@@ -73,35 +76,38 @@ class CodeCoverage(object):
 
             return None
 
-        def retrieve_coverage_task(limit=200):
-            reply = self.queue.listTaskGroup(
-                group_id,
-                limit=limit,
-            )
-            task = maybe_trigger(reply['tasks'])
+        def load_tasks(limit=200, continuationToken=None):
+            query = {
+                'limit': limit,
+            }
+            if continuationToken is not None:
+                query['continuationToken'] = continuationToken
+            reply = retry(lambda: self.queue.listTaskGroup(group_id, query=query))
+            return maybe_trigger(reply['tasks']), reply.get('continuationToken')
 
-            while task is None and reply.get('continuationToken') is not None:
-                reply = self.queue.listTaskGroup(
-                    group_id,
-                    limit=limit,
-                    continuationToken=reply['continuationToken'],
-                )
-                task = maybe_trigger(reply['tasks'])
+        async def retrieve_coverage_task():
+            task, token = load_tasks()
+
+            while task is None and token is not None:
+                task, token = load_tasks(continuationToken=token)
+
+                # Let other tasks run on long batches
+                await asyncio.sleep(2)
 
             return task
 
         try:
-            return retry(retrieve_coverage_task)
+            return await retrieve_coverage_task()
         except requests.exceptions.HTTPError:
             return None
 
-    def parse(self, body):
+    async def parse(self, body):
         '''
         Extract revisions from payload
         '''
         taskGroupId = body['taskGroupId']
 
-        build_task = self.get_build_task_in_group(taskGroupId)
+        build_task = await self.get_build_task_in_group(taskGroupId)
         if build_task is None:
             return None
 

--- a/src/pulselistener/pulselistener/listener.py
+++ b/src/pulselistener/pulselistener/listener.py
@@ -92,7 +92,7 @@ class CodeCoverage(object):
                 task, token = load_tasks(continuationToken=token)
 
                 # Let other tasks run on long batches
-                await asyncio.sleep(2)
+                await asyncio.sleep(0)
 
             return task
 

--- a/src/pulselistener/requirements.nix
+++ b/src/pulselistener/requirements.nix
@@ -187,6 +187,45 @@ let
       };
     };
 
+    "aioredis" = python.mkDerivation {
+      name = "aioredis-1.2.0";
+      src = pkgs.fetchurl {
+        url = "https://files.pythonhosted.org/packages/2e/a3/cd122b68d8071d332972027d225f548e0206001da1aa0685ea08db803b06/aioredis-1.2.0.tar.gz";
+        sha256 = "06i53xpz4x6qrmdxqwvkpd17lbgmwfq20v0jrwc73f5y57kjpml4";
+      };
+      doCheck = commonDoCheck;
+      checkPhase = "";
+      installCheckPhase = "";
+      buildInputs = commonBuildInputs ++ [ ];
+      propagatedBuildInputs = [
+        self."hiredis"
+        self."async-timeout"
+      ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://github.com/aio-libs/aioredis";
+        license = licenses.mit;
+        description = "asyncio (PEP 3156) Redis client library.";
+      };
+    };
+
+    "hiredis" = python.mkDerivation {
+      name = "hiredis-1.0.0";
+      src = pkgs.fetchurl {
+        url = "https://files.pythonhosted.org/packages/9e/e0/c160dbdff032ffe68e4b3c576cba3db22d8ceffc9513ae63368296d1bcc8/hiredis-1.0.0.tar.gz";
+        sha256 = "158pymdlnv4d218w66i8kzdn4ka30l1pdwa0wyjh16bj10zraz79";
+      };
+      doCheck = commonDoCheck;
+      checkPhase = "";
+      installCheckPhase = "";
+      buildInputs = commonBuildInputs ++ [ ];
+      propagatedBuildInputs = [];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://github.com/redis/hiredis-py";
+        license = licenses.mit;
+        description = "High speed redis client";
+      };
+    };
+
     "async-timeout" = python.mkDerivation {
       name = "async-timeout-3.0.1";
       src = pkgs.fetchurl {

--- a/src/pulselistener/requirements.txt
+++ b/src/pulselistener/requirements.txt
@@ -1,5 +1,6 @@
 -e ./../../lib/cli_common[pulse,taskcluster,log] #egg=mozilla-cli-common
 
 aiohttp
+aioredis
 pytoml
 libmozdata>=0.1.58

--- a/src/pulselistener/requirements_frozen.txt
+++ b/src/pulselistener/requirements_frozen.txt
@@ -1,5 +1,6 @@
 aioamqp==0.12.0
 aiohttp==3.5.4
+aioredis==1.2.0
 asn1crypto==0.24.0
 async-timeout==3.0.1
 atomicwrites==1.3.0

--- a/src/pulselistener/tests/conftest.py
+++ b/src/pulselistener/tests/conftest.py
@@ -23,6 +23,7 @@ from pulselistener.lib.mercurial import Repository
 from pulselistener.lib.phabricator import PhabricatorActions
 
 MOCK_DIR = os.path.join(os.path.dirname(__file__), 'mocks')
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
 
 
 @pytest.fixture


### PR DESCRIPTION
## Part 1: Update mercurial to 5.1 
... and use up-to-date version-control-tools

## Part 2 : Support 3 clone modes, configurable through TC secret

* Batch_checkout (as before)
* Robustcheckout
* Default Hg clone
This change is not mandatory, as i made it to debug pulselistener crashes on a day where the HG payload on the cdn was corrupted (when i understood the issue, i reported it on #vcs, it was fixed in a few minutes…)
But, having robustcheckout is nice to have for smaller repos like nss

## Part 3: Redis support in Message bus
It’s only used for the incoming HTTP notifications. As it’s limited in scope, it was simple to implement (dump the pickled objects in a redis list). But the benefits are immediate: even if pulselistener crashes, we do not lose anymore the build notifications from the previous instances

## Part 4: Fix the end of life cycle.

The web process was not stopped on crashes (only on KeyboardInterrupt…) I simplified the old run_consumer function from release-services into a run_tasks that use a cancellable task (still using asyncio.gather) and avoiding the run_forever. Basically the program now can stop cleanly. This allows Heroku to restart immediately pulselistener instead of waiting without doing nothing

## Part 5: Fix a nasty bug in the Taskcluster lib usage for code coverage

the limit & continuationToken were passed as kwargs and ignored by the lib (instead we need to provice them as a query).
The function was always returning the same set of tasks on the first page, which is fine in most cases where the number of tasks is below the limit (1000), but on those rare task group with more than 1000 tasks, it was locking the whole program and always retrieving that first page.
While debugging this, i found out that the code coverage part of pulselistener was spending way more time than i thought retrieving those Taskcluster payloads. So i cleaned up the code around that part, added some logging, a better retry, and made it async to allow a small asyncio.sleep so it does not lock other processes while working on big batches.

## Part 6: Simplification of the pulse connection logic

In order to remove an extra useless while True (useless for us because we already run that code in a while True).
