### PR TITLE
setup: Disable pulselistener deploy on heroku & remove from dockerhub.

### DIFF
--- a/lib/please_cli/please_cli/config.py
+++ b/lib/please_cli/please_cli/config.py
@@ -383,7 +383,7 @@ PROJECTS_CONFIG = {
                 'target': 'HEROKU',
                 'options': {
                     'testing': {
-                        'enable': True,
+                        'enable': False,
                         'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-testing-pulse-listener',
                         'heroku_dyno_type': 'web',
@@ -399,38 +399,12 @@ PROJECTS_CONFIG = {
                         'dns': 'immense-refuge-f4ii4ur88iq0x707ybzq5mfn.herokudns.com',
                     },
                     'production': {
-                        'enable': True,
+                        'enable': False,
                         'nix_path_attribute': 'docker',
                         'heroku_app': 'shipit-production-pulse-listen',
                         'heroku_dyno_type': 'web',
                         'url': 'https://eventlistener.moz.tools',
                         'dns': 'convex-woodland-ilwk96s11s92e5otfkmb5ybe.herokudns.com',
-                    },
-                },
-            },
-            {
-                'target': 'DOCKERHUB',
-                'options': {
-                    'testing': {
-                        'enable': True,
-                        'nix_path_attribute': 'docker',
-                        'docker_registry': 'index.docker.io',
-                        'docker_repo': 'mozilla/release-services',
-                        'docker_stable_tag': 'eventlistener-testing',
-                    },
-                    'staging': {
-                        'enable': False,
-                        'nix_path_attribute': 'docker',
-                        'docker_registry': 'index.docker.io',
-                        'docker_repo': 'mozilla/release-services',
-                        'docker_stable_tag': 'eventlistener-staging',
-                    },
-                    'production': {
-                        'enable': True,
-                        'nix_path_attribute': 'docker',
-                        'docker_registry': 'index.docker.io',
-                        'docker_repo': 'mozilla/release-services',
-                        'docker_stable_tag': 'eventlistener-production',
                     },
                 },
             },


### PR DESCRIPTION
As the version from #2244 is currently in use, and should be the last deployment.