### PR TITLE
Revert "Centralize version parsing in mozilla-version 0.4.x"

### DIFF
--- a/src/shipit/api/shipit_api/models.py
+++ b/src/shipit/api/shipit_api/models.py
@@ -165,7 +165,7 @@ class Release(db.Model):
     def generate_phases(self, partner_urls=None, github_token=None):
         phases = []
         previous_graph_ids = [self.decision_task_id]
-        next_version = bump_version(self.product, self.version)
+        next_version = bump_version(self.version.replace('esr', ''))
         input_common = {
             'build_number': self.build_number,
             'next_version': next_version,

--- a/src/shipit/api/shipit_api/product_details.py
+++ b/src/shipit/api/shipit_api/product_details.py
@@ -20,10 +20,10 @@ import urllib.parse
 import aiohttp
 import arrow
 import click
+import mozilla_version.gecko
 import mypy_extensions
 import sqlalchemy
 import sqlalchemy.orm
-from mozilla_version.gecko import FennecVersion
 
 import cli_common.command
 import cli_common.log
@@ -32,7 +32,6 @@ import shipit_api.config
 import shipit_api.models
 from shipit_api.release import Product
 from shipit_api.release import ProductCategory
-from shipit_api.release import parse_version
 
 logger = cli_common.log.get_logger(__name__)
 
@@ -169,6 +168,21 @@ def to_isoformat(d: datetime.datetime) -> str:
 
 def to_format(d: datetime.datetime, format: str) -> str:
     return arrow.get(d).format(format)
+
+
+def get_product_mozilla_version(product: Product,
+                                version: str,
+                                ) -> typing.Optional[mozilla_version.gecko.GeckoVersion]:
+    klass = {
+        Product.DEVEDITION: mozilla_version.gecko.DeveditionVersion,
+        Product.FIREFOX: mozilla_version.gecko.FirefoxVersion,
+        Product.FENNEC: mozilla_version.gecko.FennecVersion,
+        Product.THUNDERBIRD: mozilla_version.gecko.ThunderbirdVersion,
+    }.get(product)
+
+    if klass:
+        return klass.parse(version)
+    return None
 
 
 def create_index_listing_html(folder: pathlib.Path,
@@ -401,8 +415,13 @@ def get_releases(breakpoint_version: int,
 
         old_releases = typing.cast(typing.Dict[str, ReleaseDetails], old_product_details[product_file].get('releases', dict()))  # noqa
         for product_with_version in old_releases:
-            version = parse_version(product, product_with_version[len(product.value) + 1:])
-            if version.major_number >= breakpoint_version:
+            # mozilla_version.gecko.GeckoVersion does not parse rc (yet)
+            # https://github.com/mozilla-releng/mozilla-version/pull/40
+            #
+            # version = get_product_mozilla_version(product, product_with_version[len(product.value) + 1:])
+            # if version.major_number >= breakpoint_version:
+            version = int(product_with_version[len(product.value) + 1:].split('.')[0])
+            if version >= breakpoint_version:
                 continue
             details[product_with_version] = old_releases[product_with_version]
 
@@ -479,11 +498,16 @@ def get_release_history(breakpoint_version: int,
         product_file = f'1.0/mobile_history_{product_category.name.lower()}_releases.json'
 
     old_history = typing.cast(ReleasesHistory, old_product_details[product_file])
-    for version_string in old_history:
-        version = parse_version(product, version_string)
-        if version.major_number >= breakpoint_version:
+    for product_with_version in old_history:
+        # mozilla_version.gecko.GeckoVersion does not parse rc (yet)
+        # https://github.com/mozilla-releng/mozilla-version/pull/40
+        #
+        # version = get_product_mozilla_version(product, product_with_version[len(product.value) + 1:])
+        # if version.major_number >= breakpoint_version:
+        version = int(product_with_version.split('.')[0])
+        if version >= breakpoint_version:
             continue
-        history[version_string] = old_history[version_string]
+        history[product_with_version] = old_history[product_with_version]
 
     #
     # get release history from the database
@@ -495,7 +519,7 @@ def get_release_history(breakpoint_version: int,
         if release.status != 'shipped':
             continue
 
-        release_version = parse_version(release.product, release.version)
+        release_version = get_product_mozilla_version(Product(release.product), release.version)
         if release_version is None or release_version.major_number < breakpoint_version:
             continue
 
@@ -645,8 +669,7 @@ def get_latest_version(releases: typing.List[shipit_api.models.Release],
     releases_ = sorted(
         filtered_releases,
         reverse=True,
-        key=lambda r: parse_version(product, r.version)
-    )
+        key=lambda r: get_product_mozilla_version(Product(product), r.version))
     if len(releases_) == 0:
         # XXX: should we fallback to old_product_details?
         return ''
@@ -969,12 +992,12 @@ def get_mobile_versions(releases: typing.List[shipit_api.models.Release]) -> Mob
         beta_version=get_latest_version(releases,
                                         shipit_api.config.FENNEC_BETA_BRANCH,
                                         Product.FENNEC,
-                                        lambda r: FennecVersion.parse(r.version).is_beta
+                                        lambda r: mozilla_version.gecko.FennecVersion.parse(r.version).is_beta
                                         ),
         version=get_latest_version(releases,
                                    shipit_api.config.FENNEC_RELEASE_BRANCH,
                                    Product.FENNEC,
-                                   lambda r: FennecVersion.parse(r.version).is_release
+                                   lambda r: mozilla_version.gecko.FennecVersion.parse(r.version).is_release
                                    ),
     )
 

--- a/src/shipit/api/tests/test_release.py
+++ b/src/shipit/api/tests/test_release.py
@@ -3,72 +3,79 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from contextlib import nullcontext as does_not_raise
-
 import pytest
-from mozilla_version.gecko import DeveditionVersion
-from mozilla_version.gecko import FennecVersion
-from mozilla_version.gecko import FirefoxVersion
-from mozilla_version.gecko import ThunderbirdVersion
 
-from shipit_api.release import Product
 from shipit_api.release import bump_version
+from shipit_api.release import is_beta
 from shipit_api.release import is_eme_free_enabled
+from shipit_api.release import is_esr
+from shipit_api.release import is_final_release
 from shipit_api.release import is_partner_enabled
 from shipit_api.release import is_rc
-from shipit_api.release import parse_version
 
 
-@pytest.mark.parametrize('product, version, expectation, result', (
-    ('devedition', '56.0b1', does_not_raise(), DeveditionVersion(56, 0, beta_number=1)),
-    (Product.DEVEDITION, '56.0b1', does_not_raise(), DeveditionVersion(56, 0, beta_number=1)),
-    ('fennec', '68.2b3', does_not_raise(), FennecVersion(68, 2, beta_number=3)),
-    (Product.FENNEC, '68.2b3', does_not_raise(), FennecVersion(68, 2, beta_number=3)),
-    ('firefox', '45.0', does_not_raise(), FirefoxVersion(45, 0)),
-    (Product.FIREFOX, '45.0', does_not_raise(), FirefoxVersion(45, 0)),
-    ('thunderbird', '60.8.0', does_not_raise(), ThunderbirdVersion(60, 8, 0)),
-    (Product.THUNDERBIRD, '60.8.0', does_not_raise(), ThunderbirdVersion(60, 8, 0)),
-    ('non-existing-product', '68.0', pytest.raises(ValueError), None),
+@pytest.mark.parametrize('version, result', (
+    ('57.0', True),
+    ('7.0', True),
+    ('123.0', True),
+    ('56.0b3', False),
+    ('41.0esr', False),
+    ('78.0.1', False),
 ))
-def test_parse_version(product, version, expectation, result):
-    with expectation:
-        assert parse_version(product, version) == result
+def test_is_final_version(version, result):
+    assert is_final_release(version) == result
+
+
+@pytest.mark.parametrize('version, result', (
+    ('57.0', False),
+    ('7.0', False),
+    ('123.0', False),
+    ('56.0b3', True),
+    ('41.0esr', False),
+    ('78.0.1', False),
+))
+def test_is_beta(version, result):
+    assert is_beta(version) == result
+
+
+@pytest.mark.parametrize('version, result', (
+    ('57.0', False),
+    ('7.0', False),
+    ('123.0', False),
+    ('56.0b3', False),
+    ('41.0esr', True),
+    ('78.0.1', False),
+))
+def test_is_esr(version, result):
+    assert is_esr(version) == result
 
 
 @pytest.mark.parametrize('product, version, partial_updates, result', (
+    ('firefox', '57.0', {'56.0b1': [], '55.0': []}, True),
+    ('firefox', '57.0', {'56.0': [], '55.0': []}, True),
+    ('thunderbird', '57.0', {'56.0': [], '55.0': []}, False),
     ('firefox', '64.0', None, True),
     ('thunderbird', '64.0', None, False),
     ('fennec', '64.0', None, True),
     ('firefox', '64.0.1', None, False),
     ('thunderbird', '64.0.1', None, False),
-    ('fennec', '64.0.1', None, False),
-    ('firefox', '56.0b3', None, False),
     ('fennec', '56.0b3', None, False),
-    ('firefox', '45.0esr', None, False),
-
-    ('firefox', '57.0', {'56.0b1': [], '55.0': []}, True),
-    ('firefox', '57.0', {'56.0': [], '55.0': []}, True),
-    ('firefox', '57.0.1', {'57.0': [], '56.0.1': [], '56.0': []}, False),
-    ('thunderbird', '57.0', {'56.0': [], '55.0': []}, False),
-    ('thunderbird', '57.0', {'56.0': [], '56.0b4': [], '55.0': []}, True),
-    ('firefox', '70.0b4', {'69.0b15': [], '69.0b16': [], '70.0b3': []}, False),
-    ('devedition', '70.0b4', {'70.0b3': [], '70.0b1': [], '70.0b2': []}, False),
+    ('firefox', '41.0esr', None, False),
 ))
 def test_is_rc(product, version, partial_updates, result):
     assert is_rc(product, version, partial_updates) == result
 
 
-@pytest.mark.parametrize('product, version, result', (
-    ('firefox', '45.0', '45.0.1'),
-    ('firefox', '45.0.1', '45.0.2'),
-    ('firefox', '45.0b3', '45.0b4'),
-    ('firefox', '45.0esr', '45.0.1esr'),
-    ('firefox', '45.0.1esr', '45.0.2esr'),
-    ('firefox', '45.2.1esr', '45.2.2esr'),
-    ('fennec', '68.1b2', '68.1b3'),
+@pytest.mark.parametrize('version, result', (
+    ('45.0', '45.0.1'),
+    ('45.0.1', '45.0.2'),
+    ('45.0b3', '45.0b4'),
+    ('45.0esr', '45.0.1esr'),
+    ('45.0.1esr', '45.0.2esr'),
+    ('45.2.1esr', '45.2.2esr'),
 ))
-def test_bump_version(product, version, result):
-    assert bump_version(product, version) == result
+def test_bump_version(version, result):
+    assert bump_version(version) == result
 
 
 @pytest.mark.parametrize('product, version, result', (


### PR DESCRIPTION
Reverts mozilla/release-services#2262

#2262 is causing new trouble with Fennec ESR. @RyanVM tried to create fennec 68.1.1 in ship-it, and here's the error he got:
`"Product fennec_release versions are not supported"` 

It's cause by: https://github.com/mozilla/release-services/blob/3c014486c4b0a69fd65284e174dfb4226566274a/src/shipit/api/shipit_api/release.py#L47